### PR TITLE
Fix vendor toc newline

### DIFF
--- a/EnhanceQoLVendor/EnhanceQoLVendor.toc
+++ b/EnhanceQoLVendor/EnhanceQoLVendor.toc
@@ -12,7 +12,8 @@
 ## Notes-ruRU: Автоматически продаёт различные предметы на основе фильтров
 ## Notes-koKR: 필터에 따라 다양한 아이템을 자동으로 판매합니다
 ## Notes-zhCN: 根据筛选器自动出售不同物品
-## Notes-zhTW: 根據過濾器自動出售不同物品## Dependencies: EnhanceQoL
+## Notes-zhTW: 根據過濾器自動出售不同物品
+## Dependencies: EnhanceQoL
 ## IconTexture: Interface\AddOns\EnhanceQoLVendor\Icons\Icon.tga
 ## Dependencies: EnhanceQoL
 ## Retail: true


### PR DESCRIPTION
## Summary
- fix newline after zhTW notes so `## Dependencies:` starts on its own line

## Testing
- `grep -n "Notes-zhTW" EnhanceQoLVendor/EnhanceQoLVendor.toc`
