### PR TITLE
Fix collapsing layout of bag filter sections

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -3086,8 +3086,9 @@ local function initCharacter()
 	addon.functions.InitDBValue("showGemsOnCharframe", false)
 	addon.functions.InitDBValue("showGemsTooltipOnCharframe", false)
 	addon.functions.InitDBValue("showEnchantOnCharframe", false)
-	addon.functions.InitDBValue("showCatalystChargesOnCharframe", false)
-	addon.functions.InitDBValue("bagFilterFrameData", {})
+        addon.functions.InitDBValue("showCatalystChargesOnCharframe", false)
+        addon.functions.InitDBValue("bagFilterFrameData", {})
+        addon.functions.InitDBValue("bagFilterCollapsed", {})
 
 	hooksecurefunc(ContainerFrameCombinedBags, "UpdateItems", addon.functions.updateBags)
 	for _, frame in ipairs(ContainerFrameContainer.ContainerFrames) do

--- a/EnhanceQoL/General/functions.lua
+++ b/EnhanceQoL/General/functions.lua
@@ -544,13 +544,60 @@ local function checkActiveBindFilter()
 end
 
 local function checkActiveUpgradeFilter()
-	for _, value in pairs(addon.itemBagFiltersUpgrade) do
-		if value == true then
-			addon.itemBagFilters["upgrade"] = true
-			return
-		end
-	end
-	addon.itemBagFilters["upgrade"] = false
+        for _, value in pairs(addon.itemBagFiltersUpgrade) do
+                if value == true then
+                        addon.itemBagFilters["upgrade"] = true
+                        return
+                end
+        end
+        addon.itemBagFilters["upgrade"] = false
+end
+
+local function createCollapsibleSection(parent, title, key)
+       local group = AceGUI:Create("SimpleGroup")
+       group:SetFullWidth(true)
+       group:SetLayout("List")
+
+       local header = AceGUI:Create("InteractiveLabel")
+       header:SetText("|cffffd100" .. title .. "|r")
+       header:SetFont(addon.variables.defaultFont, 12, "OUTLINE")
+       header:SetFullWidth(true)
+       header:SetImageSize(14, 14)
+       group:AddChild(header)
+
+       local content = AceGUI:Create("SimpleGroup")
+       content:SetFullWidth(true)
+       content:SetLayout("Flow")
+       group:AddChild(content)
+
+       addon.db.bagFilterCollapsed = addon.db.bagFilterCollapsed or {}
+       local collapsed = addon.db.bagFilterCollapsed[key]
+       if collapsed == nil then
+               collapsed = true
+               addon.db.bagFilterCollapsed[key] = true
+       end
+
+       local function refresh()
+               if collapsed then
+                       content.frame:Hide()
+                       header:SetImage("Interface\\Buttons\\UI-PlusButton-Up")
+               else
+                       content.frame:Show()
+                       header:SetImage("Interface\\Buttons\\UI-MinusButton-Up")
+               end
+               group:DoLayout()
+               parent:DoLayout()
+       end
+
+       header:SetCallback("OnClick", function()
+               collapsed = not collapsed
+               addon.db.bagFilterCollapsed[key] = collapsed
+               refresh()
+       end)
+
+       parent:AddChild(group)
+       refresh()
+       return content, header
 end
 
 local function CreateFilterMenu()
@@ -605,20 +652,15 @@ local function CreateFilterMenu()
 
 	local longestWidth = 200
 	local math_max = math.max
-	-- Dynamisch die UI-Elemente aus `filterData` erstellen
-	for _, section in ipairs(filterData) do
-		-- Überschrift für jede Sektion
-		local label = AceGUI:Create("Label")
-		label:SetText("|cffffd100" .. section.label .. "|r") -- Goldene Überschrift
-		label:SetFont(addon.variables.defaultFont, 12, "OUTLINE")
-		label:SetFullWidth(true)
-		scrollContainer:AddChild(label)
+       -- Dynamisch die UI-Elemente aus `filterData` erstellen
+       for idx, section in ipairs(filterData) do
+               local content, header = createCollapsibleSection(scrollContainer, section.label, tostring(idx))
 
-		longestWidth = math_max(label.label:GetStringWidth(), longestWidth)
+               longestWidth = math_max(header.label:GetStringWidth(), longestWidth)
 
-		-- Füge die Kind-Elemente hinzu
-		for _, item in ipairs(section.child) do
-			local widget
+               -- Füge die Kind-Elemente hinzu
+               for _, item in ipairs(section.child) do
+                       local widget
 
 			if item.type == "CheckBox" then
 				widget = AceGUI:Create("CheckBox")
@@ -667,7 +709,7 @@ local function CreateFilterMenu()
 				local eLabel = AceGUI:Create("Label")
 				eLabel:SetText(item.label)
 				eLabel:SetRelativeWidth(0.48)
-				scrollContainer:AddChild(eLabel)
+                               content:AddChild(eLabel)
 				widget = AceGUI:Create("EditBox")
 				-- widget:SetLabel(item.label) -- REMOVED: label now handled by separate label above
 				widget:SetWidth(50)
@@ -709,7 +751,7 @@ local function CreateFilterMenu()
 
 			if widget then
 				if item.type ~= "EditBox" or (item.key ~= "minLevel" and item.key ~= "maxLevel") then widget:SetFullWidth(true) end
-				scrollContainer:AddChild(widget)
+                               content:AddChild(widget)
 				if widget.text and widget.text.GetStringWidth then longestWidth = math_max(widget.text:GetStringWidth(), longestWidth) end
 			end
 		end


### PR DESCRIPTION
## Summary
- update `createCollapsibleSection` so the layout recalculates when toggling
- ensure the parent panel is refreshed to remove empty space

## Testing
- `luacheck EnhanceQoL/General/functions.lua`
- `luacheck .`
