### PR TITLE
Enhance ChatIM whisper shortcuts

### DIFF
--- a/EnhanceQoL/Submodules/ChatIM/Core.lua
+++ b/EnhanceQoL/Submodules/ChatIM/Core.lua
@@ -43,3 +43,38 @@ local function whisperFilter() return true end
 
 SLASH_EQOLIM1 = "/im"
 SlashCmdList["EQOLIM"] = function() ChatIM:Toggle() end
+
+-- save original whisper handlers and replace with wrappers
+ChatIM.origWhisper = SlashCmdList["WHISPER"]
+ChatIM.origReply = SlashCmdList["REPLY"]
+
+local function focusTab(target)
+       ChatIM:CreateTab(target)
+       if ChatIM.widget and ChatIM.widget.frame and not ChatIM.widget.frame:IsShown() then
+               UIFrameFlashStop(ChatIM.widget.frame)
+               ChatIM.widget.frame:Show()
+       end
+       local tab = ChatIM.tabs[target]
+       if tab and tab.edit then
+               ChatIM.tabGroup:SelectTab(target)
+               tab.edit:SetFocus()
+       end
+end
+
+SlashCmdList["WHISPER"] = function(msg, editBox)
+       local target, text = msg:match("^%s*(%S+)%s*(.*)$")
+       if target and text == "" then
+               focusTab(target)
+       else
+               ChatIM.origWhisper(msg, editBox)
+       end
+end
+
+SlashCmdList["REPLY"] = function(msg, editBox)
+       if msg:match("^%s*$") then
+               local target = ChatEdit_GetLastTellTarget()
+               if target then focusTab(target) end
+       else
+               ChatIM.origReply(msg, editBox)
+       end
+end


### PR DESCRIPTION
## Summary
- wrap default `/w` and `/r` commands
- when invoked without a message, open ChatIM and focus the whisper tab

## Testing
- `luacheck EnhanceQoL/Submodules/ChatIM/Core.lua`
- `npx stylua --version` *(fails: EHOSTUNREACH)*