### PR TITLE
Add ignore toggle to chat

### DIFF
--- a/EnhanceQoL/Submodules/ChatIM/Core.lua
+++ b/EnhanceQoL/Submodules/ChatIM/Core.lua
@@ -75,3 +75,19 @@ SLASH_EQOLIM1 = "/eim"
 SlashCmdList["EQOLIM"] = function()
 	if ChatIM.enabled then ChatIM:Toggle() end
 end
+
+function ChatIM:ToggleIgnore(name)
+       if C_FriendList.IsIgnored and C_FriendList.IsIgnored(name) or IsIgnored and IsIgnored(name) then
+               if C_FriendList.DelIgnore then
+                       C_FriendList.DelIgnore(name)
+               else
+                       DelIgnore(name)
+               end
+       else
+               if C_FriendList.AddIgnore then
+                       C_FriendList.AddIgnore(name)
+               else
+                       AddIgnore(name)
+               end
+       end
+end

--- a/EnhanceQoL/Submodules/ChatIM/UI.lua
+++ b/EnhanceQoL/Submodules/ChatIM/UI.lua
@@ -33,7 +33,12 @@ local function PlayerMenuGenerator(_, root, targetName)
 	root:CreateTitle(UNIT_FRAME_DROPDOWN_SUBSECTION_TITLE_OTHER)
 
 	root:CreateButton(COPY_CHARACTER_NAME, function(name) StaticPopup_Show("EQOL_URL_COPY", nil, nil, name) end, targetName)
-	root:CreateButton(IGNORE, function(name) C_FriendList.AddIgnore(name) end, targetName)
+
+	local label = IsIgnored(targetName) and UNIGNORE_QUEST or IGNORE
+	local function toggleIgnore(name)
+	ChatIM:ToggleIgnore(name)
+	end
+	root:CreateButton(label, toggleIgnore, targetName)
 end
 
 StaticPopupDialogs["EQOL_URL_COPY"] = {


### PR DESCRIPTION
## Summary
- support toggling ignore status in ChatIM core
- show UNIGNORE_QUEST when target is already ignored

## Testing
- `pre-commit` *(fails: command not found)*