### PR TITLE
Fix censored message replacement

### DIFF
--- a/EnhanceQoL/Submodules/ChatIM/UI.lua
+++ b/EnhanceQoL/Submodules/ChatIM/UI.lua
@@ -333,38 +333,38 @@ function ChatIM:CreateTab(sender, isBN, bnetID)
 			return
 		end
 
-               if linkType == "censoredmessage" then
-                        local _, censorID = string.split(":", linkData)
-                        if censorID then
-                                _G.C_ChatInfo.UncensorChatLine(censorID)
-                                local text = C_ChatInfo.GetChatLineText(censorID)
-                                if text then
-                                        text = ChatIM:FormatURLs(text)
-                                        local hidden = CENSORED_MESSAGE_HIDDEN:format(sender, censorID)
-                                        local report = CENSORED_MESSAGE_REPORT:format(censorID)
-                                        local history = ChatIM.history[sender]
-                                        local replaced
-                                        if history then
-                                                for i, line in ipairs(history) do
-                                                        if line:find(hidden, 1, true) then
-                                                                local escHidden = hidden:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
-                                                                local escReport = report:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
-                                                                history[i] = line:gsub(escHidden, text, 1):gsub(escReport, "", 1)
-                                                                replaced = true
-                                                                break
-                                                        end
-                                                end
-                                        end
-                                        if replaced and history then
-                                                frame:Clear()
-                                                for _, line in ipairs(history) do
-                                                        frame:AddMessage(line)
-                                                end
-                                        end
-                                end
-                        end
-                        return
-                end
+		if linkType == "censoredmessage" then
+			local _, censorID = string.split(":", linkData)
+			if censorID then
+				_G.C_ChatInfo.UncensorChatLine(censorID)
+				local text = C_ChatInfo.GetChatLineText(censorID)
+				if text then
+					text = ChatIM:FormatURLs(text)
+					local hidden = CENSORED_MESSAGE_HIDDEN:format(sender, censorID)
+					local report = CENSORED_MESSAGE_REPORT:format(censorID)
+					local history = ChatIM.history[sender]
+					local replaced
+					if history then
+						for i, line in ipairs(history) do
+							if line:find(hidden, 1, true) then
+								local escHidden = hidden:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
+								local escReport = report:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
+								history[i] = line:gsub(escHidden, text, 1):gsub(escReport, "", 1)
+								replaced = true
+								break
+							end
+						end
+					end
+					if replaced and history then
+						frame:Clear()
+						for _, line in ipairs(history) do
+							frame:AddMessage(line)
+						end
+					end
+				end
+			end
+			return
+		end
 
 		-- Alles andere an Blizzard weiterreichen
 		ChatFrame_OnHyperlinkShow(frame, linkData, text, button)


### PR DESCRIPTION
## Summary
- handle `censoredmessage` hyperlink by replacing the placeholder string with the decoded text
- declare global strings for luacheck

## Testing
- `luacheck .`
