### PR TITLE
Persist Battle.net history by BattleTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### ✨ Changed
+- Instant Messenger now stores Battle.net message history by BattleTag to keep chat logs across sessions.
+
 ## [3.17.0] – 2025-05-29
 ### ✨ Added
 - **Instant Messenger** – Option to enable  incoming and outgoing whispers to appear in a compact IM window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Changelog
 
-## [Unreleased]
-### ✨ Changed
-- Instant Messenger now stores Battle.net message history by BattleTag to keep chat logs across sessions.
-
-## [3.17.0] – 2025-05-29
-### ✨ Added
-- **Instant Messenger** – Option to enable  incoming and outgoing whispers to appear in a compact IM window.
-  - Each conversation opens in its own tab, which flashes on new messages.
-  - Use `/eim` to toggle the window; it can fade when losing focus.
+## [3.17.0] – 2025-05-29  
+### ✨ Added  
+- **Instant Messenger** – Option to show incoming **and** outgoing whispers in a compact IM-style window.
+  - Each conversation opens in its own tab, which flashes when a new message arrives.
+  - Toggle the window with `/eim`; it can optionally fade when it loses focus.
+  - Persistent history stores up to **1,000 messages per player**
+    - History can be cleared per player or wiped entirely via the options panel.
 
 ## [3.16.0] – 2025-05-26
 ### ✨ Added

--- a/EnhanceQoL/Submodules/ChatIM/UI.lua
+++ b/EnhanceQoL/Submodules/ChatIM/UI.lua
@@ -406,7 +406,7 @@ function ChatIM:CreateTab(sender, isBN, bnetID, battleTag)
 
 		for _, line in ipairs(ChatIM.history[historyKey]) do
 			if isBN then
-				smf:AddMessage(string.format(line, sender))
+				smf:AddMessage(string.format(line, sender, sender))
 			else
 				smf:AddMessage(line)
 			end
@@ -483,7 +483,12 @@ function ChatIM:AddMessage(partner, text, outbound, isBN, bnetID)
 	local historyKey = isBN and tab.battleTag or partner
 	local storeLine
 	if isBN then
-		local nameLinkFmt = string.format("|HBNplayer:%%s|h[%s]|h", shortName)
+		local nameLinkFmt
+		if outbound then
+			nameLinkFmt = "|HBNplayer:%s|h[" .. AUCTION_HOUSE_SELLER_YOU .. "]|h"
+		else
+			nameLinkFmt = "|HBNplayer:%s|h[%s]|h"
+		end
 		storeLine = string.format("%s |cff%s%s|r: |cff%s%s|r", prefix, cHex, nameLinkFmt, cHex, text)
 	else
 		storeLine = line


### PR DESCRIPTION
## Summary
- ensure ChatIM tabs record battleTag for Battle.net whispers
- store BN history keyed by battleTag with placeholder for session token
- render stored lines with the current session token
- document the change in the changelog

## Testing
- `luacheck EnhanceQoL/Submodules/ChatIM/UI.lua`
- `./scripts/build.sh` *(fails: `sed: can't read s/@project-version@/3.16.0-75-g34ce4ed/: No such file or directory`)*