### PR TITLE
Add auto-tab open when whisper starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## [3.17.0] – 2025-05-29  
+## [3.17.1] – 2025-05-30
 ### 🐛 Fixed
 - Frame Strata of ChatIM was to high
 - Some letter like "g" where slightly overlapped by the editbox
 - /r and Shift+r didn't work with ChatIM enabled
 
-## [3.17.0] – 2025-05-29  
+## [3.17.0] – 2025-05-29
 ### ✨ Added  
 - **Instant Messenger** – Option to show incoming **and** outgoing whispers in a compact IM-style window.
   - Each conversation opens in its own tab, which flashes when a new message arrives.

--- a/EnhanceQoL/Submodules/ChatIM/Core.lua
+++ b/EnhanceQoL/Submodules/ChatIM/Core.lua
@@ -118,7 +118,6 @@ local function updateRegistration()
 		frame:RegisterEvent("CHAT_MSG_BN_WHISPER")
 		frame:RegisterEvent("CHAT_MSG_WHISPER_INFORM")
 		frame:RegisterEvent("CHAT_MSG_BN_WHISPER_INFORM")
-		frame:RegisterEvent("CHAT_MSG_BN_WHISPER_INFORM")
 		if addon.db and addon.db["chatIMHideInCombat"] then
 			frame:RegisterEvent("PLAYER_REGEN_DISABLED")
 			frame:RegisterEvent("PLAYER_REGEN_ENABLED")
@@ -149,6 +148,19 @@ function ChatIM:SetEnabled(val)
 			hooksecurefunc("ChatFrame_SendTell", function(name)
 				if not ChatIM.enabled then return end
 				if name then ChatIM:StartWhisper(name) end
+			end)
+			hooksecurefunc("ChatFrame_SendBNetTell", function(target)
+				if not ChatIM.enabled then return end
+				local bnetID = nil
+				local plain = BNTokenFindName(target) or target
+				bnetID = BNet_GetBNetIDAccount(plain)
+				target = plain
+				if bnetID then
+					local accountTag
+					local info = C_BattleNet.GetAccountInfoByID(bnetID)
+					if info then accountTag = info.battleTag end
+					if accountTag then ChatIM:StartWhisper(target, bnetID, accountTag) end
+				end
 			end)
 			self.whisperHooked = true
 		end

--- a/EnhanceQoL/Submodules/ChatIM/Core.lua
+++ b/EnhanceQoL/Submodules/ChatIM/Core.lua
@@ -9,6 +9,7 @@ end
 local ChatIM = addon.ChatIM or {}
 addon.ChatIM = ChatIM
 ChatIM.enabled = false
+ChatIM.whisperHooked = ChatIM.whisperHooked or false
 ChatIM.soundPath = "Interface\\AddOns\\" .. parentAddonName .. "\\Sounds\\ChatIM\\"
 ChatIM.availableSounds = {
 	Bell = ChatIM.soundPath .. "Bell.ogg",
@@ -144,6 +145,13 @@ function ChatIM:SetEnabled(val)
 	if self.enabled then
 		self:SetMaxHistoryLines(addon.db and addon.db["chatIMMaxHistory"])
 		self:CreateUI()
+		if not self.whisperHooked then
+			hooksecurefunc("ChatFrame_SendTell", function(name)
+				if not ChatIM.enabled then return end
+				if name then ChatIM:StartWhisper(name) end
+			end)
+			self.whisperHooked = true
+		end
 	end
 	updateRegistration()
 end

--- a/EnhanceQoL/Submodules/ChatIM/UI.lua
+++ b/EnhanceQoL/Submodules/ChatIM/UI.lua
@@ -701,9 +701,13 @@ function ChatIM:HideWindow()
 	end
 end
 
-function ChatIM:StartWhisper(target)
+function ChatIM:StartWhisper(target, bnetID, accountTag)
 	if not target then return end
-	self:CreateTab(target)
+	if bnetID then
+		self:CreateTab(target, true, bnetID, accountTag)
+	else
+		self:CreateTab(target)
+	end
 	if self.widget and self.widget.frame and not self.widget.frame:IsShown() then self:ShowWindow() end
 	if not self.tabGroup then return end
 	self.tabGroup:SelectTab(target)

--- a/EnhanceQoL/Submodules/ChatIM/UI.lua
+++ b/EnhanceQoL/Submodules/ChatIM/UI.lua
@@ -700,3 +700,13 @@ function ChatIM:HideWindow()
 		self.widget.frame:Hide()
 	end
 end
+
+function ChatIM:StartWhisper(target)
+	if not target then return end
+	self:CreateTab(target)
+	if self.widget and self.widget.frame and not self.widget.frame:IsShown() then self:ShowWindow() end
+	if not self.tabGroup then return end
+	self.tabGroup:SelectTab(target)
+	local tab = self.tabs[target]
+	if tab and tab.edit then tab.edit:SetFocus() end
+end


### PR DESCRIPTION
## Summary
- open ChatIM tab as soon as `/w <name>` is used
- new helper `StartWhisper` to create and focus tabs

## Testing
- `stylua EnhanceQoL/Submodules/ChatIM/UI.lua EnhanceQoL/Submodules/ChatIM/Core.lua`