### PR TITLE
Implement alt item search names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.18.1] – 2025-06-02
+### ✨ Added
+- **Alt Item Tracker**
+  - Central item database caches metadata for all tracked items.
+  - Search window lists items per character via `/eqolitems` with item names and counts.
+
 ## [3.18.0] – 2025-06-01
 ### ✨ Added
 - **Skyriding**

--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -1750,21 +1750,46 @@ local function addBagFrame(container)
 				end
 			end,
 		},
-		{
-			parent = BAGSLOT,
-			var = "enableMoneyTracker",
-			text = L["enableMoneyTracker"],
-			desc = L["enableMoneyTrackerDesc"],
-			type = "CheckBox",
-			callback = function(self, _, value)
-				addon.db["enableMoneyTracker"] = value
-				container:ReleaseChildren()
-				addBagFrame(container)
-			end,
-		},
-		{
-			parent = BAGSLOT,
-			var = "showIlvlOnBankFrame",
+                {
+                        parent = BAGSLOT,
+                        var = "enableMoneyTracker",
+                        text = L["enableMoneyTracker"],
+                        desc = L["enableMoneyTrackerDesc"],
+                        type = "CheckBox",
+                        callback = function(self, _, value)
+                                addon.db["enableMoneyTracker"] = value
+                                container:ReleaseChildren()
+                                addBagFrame(container)
+                        end,
+                },
+                {
+                        parent = BAGSLOT,
+                        var = "enableAltItemTracker",
+                        text = L["enableAltItemTracker"],
+                        desc = L["enableAltItemTrackerDesc"],
+                        type = "CheckBox",
+                        callback = function(self, _, value)
+                                addon.db["enableAltItemTracker"] = value
+                        end,
+                },
+                {
+                        parent = BAGSLOT,
+                        var = "showAltItemCountTooltip",
+                        text = L["TooltipShowAltItemCount"],
+                        type = "CheckBox",
+                        callback = function(self, _, value)
+                                addon.db["showAltItemCountTooltip"] = value
+                        end,
+                },
+                {
+                        parent = BAGSLOT,
+                        type = "Button",
+                        text = L["AltItemSearch"],
+                        callback = function() if addon.AltItemCache then addon.AltItemCache:ToggleWindow() end end,
+                },
+                {
+                        parent = BAGSLOT,
+                        var = "showIlvlOnBankFrame",
 			text = L["showIlvlOnBankFrame"],
 			type = "CheckBox",
 			callback = function(self, _, value)
@@ -2667,10 +2692,12 @@ local function initUnitFrame()
 end
 
 local function initBagsFrame()
-	addon.functions.InitDBValue("moneyTracker", {})
-	addon.functions.InitDBValue("enableMoneyTracker", false)
-	addon.functions.InitDBValue("showOnlyGoldOnMoney", false)
-	if addon.db["moneyTracker"][UnitGUID("player")] == nil or type(addon.db["moneyTracker"][UnitGUID("player")]) ~= "table" then addon.db["moneyTracker"][UnitGUID("player")] = {} end
+        addon.functions.InitDBValue("moneyTracker", {})
+        addon.functions.InitDBValue("enableMoneyTracker", false)
+        addon.functions.InitDBValue("showOnlyGoldOnMoney", false)
+        addon.functions.InitDBValue("enableAltItemTracker", false)
+        addon.functions.InitDBValue("showAltItemCountTooltip", false)
+        if addon.db["moneyTracker"][UnitGUID("player")] == nil or type(addon.db["moneyTracker"][UnitGUID("player")]) ~= "table" then addon.db["moneyTracker"][UnitGUID("player")] = {} end
 	local moneyFrame = ContainerFrameCombinedBags.MoneyFrame
 	local otherMoney = {}
 

--- a/EnhanceQoL/EnhanceQoL.toc
+++ b/EnhanceQoL/EnhanceQoL.toc
@@ -16,7 +16,7 @@
 ## Notes-koKR: 사소한 편의 기능으로 게임 품질을 향상합니다
 ## Notes-zhCN: 一些小调整，以改善您的游戏体验
 ## Notes-zhTW: 一些小調整，以改善您的遊戲體驗
-## SavedVariables: EnhanceQoLDB, EnhanceQoL_IMHistory
+## SavedVariables: EnhanceQoLDB, EnhanceQoL_IMHistory, EnhanceQoL_ItemCache, EnhanceQoL_ItemDB
 ## X-Wago-ID: aN0Ykv6j
 ## X-Curse-Project-ID: 1076354
 ## Retail: true
@@ -43,5 +43,6 @@ EnhanceQoL.lua
 Submodules\GemHelper.lua
 Submodules\\ChatIM\\UI.lua
 Submodules\\ChatIM\\Core.lua
+Submodules\AltItemCache.lua
 
 

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -58,6 +58,11 @@ L["UnitFrame"] = "UnitFrame"
 L["SellJunkIgnoredBag"] = "You have ignored junk on %d bags.\nThis may prevent selling all junk items automatically."
 L["enableGemHelper"] = "Enable Gem-Socket Helper"
 L["enableGemHelperDesc"] = "Displays a helper panel when you open the socketing UI.\nLeft-click a gem to pick it up."
+L["enableAltItemTracker"] = "Enable Alt Item Tracker"
+L["enableAltItemTrackerDesc"] = "Track items across all characters via a central database and open the search window with /eqolitems"
+L["TooltipShowAltItemCount"] = "Show alt item counts in tooltips"
+L["AltItemSearch"] = "Alt Item Search"
+L["Search"] = "Search"
 
 L["deleteItemFillDialog"] = 'Add "%s" to the "Delete confirmation Popup"'
 L["confirmPatronOrderDialog"] = "Automatically confirm to use own materials on %s crafting orders"

--- a/EnhanceQoL/Submodules/AltItemCache.lua
+++ b/EnhanceQoL/Submodules/AltItemCache.lua
@@ -1,0 +1,265 @@
+local parentAddonName = "EnhanceQoL"
+local addonName, addon = ...
+if _G[parentAddonName] then
+	addon = _G[parentAddonName]
+else
+	error(parentAddonName .. " is not loaded")
+end
+
+local AceGUI = addon.AceGUI
+local L = LibStub("AceLocale-3.0"):GetLocale("EnhanceQoL")
+
+addon.AltItemCache = addon.AltItemCache or {}
+local AIC = addon.AltItemCache
+
+------------------------------------------------------------
+-- SavedVariables
+------------------------------------------------------------
+EnhanceQoL_ItemDB = EnhanceQoL_ItemDB or {}
+
+------------------------------------------------------------
+-- Utility functions
+------------------------------------------------------------
+local function LinkKey(itemLink)
+	if not itemLink then return nil end
+	return itemLink:match("|H(item:[^|]+)|h")
+end
+
+local function CacheItem(link)
+	local key = LinkKey(link)
+	if not key or EnhanceQoL_ItemDB[key] then return key end
+	local itm = Item:CreateFromItemLink(link)
+	itm:ContinueOnItemLoad(function()
+		local itemID = itm:GetItemID()
+		local ilvl = itm:GetCurrentItemLevel()
+		local quality = itm:GetItemQuality()
+		local equipLoc = select(9, GetItemInfo(link))
+		local classID, subClassID = select(12, GetItemInfo(link))
+		local stats = GetItemStats(link)
+		local hasSockets = false
+		if stats then
+			for k in pairs(stats) do
+				if k:find("SOCKET", 1, true) then
+					hasSockets = true
+					break
+				end
+			end
+		end
+
+		EnhanceQoL_ItemDB[key] = {
+			link = link,
+			itemID = itemID,
+			ilvl = ilvl,
+			quality = quality,
+			equipLoc = equipLoc,
+			classID = classID,
+			subClassID = subClassID,
+			socketed = hasSockets,
+		}
+	end)
+	return key
+end
+
+local function ensureChar()
+	EnhanceQoL_ItemCache = EnhanceQoL_ItemCache or {}
+	local guid = UnitGUID("player")
+	if not EnhanceQoL_ItemCache[guid] then
+		EnhanceQoL_ItemCache[guid] = {
+			name = UnitName("player"),
+			realm = GetRealmName(),
+			class = select(2, UnitClass("player")),
+			items = {},
+			itemsByID = {},
+			index = { name = {}, id = {}, type = {} },
+		}
+	end
+	return EnhanceQoL_ItemCache[guid]
+end
+
+local function addItem(char, link, count)
+	local key = CacheItem(link)
+	if not key then return end
+	char.items[key] = (char.items[key] or 0) + (count or 1)
+	local meta = EnhanceQoL_ItemDB[key]
+	if not meta then return end
+	local itemID = meta.itemID
+	if itemID then char.itemsByID[itemID] = (char.itemsByID[itemID] or 0) + (count or 1) end
+	local name = GetItemInfo(link)
+	local itemType = select(6, GetItemInfo(link))
+	if name then
+		local nkey = strlower(name)
+		char.index.name[nkey] = char.index.name[nkey] or {}
+		char.index.name[nkey][key] = true
+	end
+	if itemID then
+		char.index.id[itemID] = char.index.id[itemID] or {}
+		char.index.id[itemID][key] = true
+	end
+	if itemType then
+		char.index.type[itemType] = char.index.type[itemType] or {}
+		char.index.type[itemType][key] = true
+	end
+end
+
+local function scanBags(includeBank)
+	if not addon.db["enableAltItemTracker"] then return end
+	local char = ensureChar()
+	wipe(char.items)
+	wipe(char.itemsByID)
+	char.index = { name = {}, id = {}, type = {} }
+	for bag = 0, NUM_TOTAL_EQUIPPED_BAG_SLOTS do
+		for slot = 1, C_Container.GetContainerNumSlots(bag) do
+			local info = C_Container.GetContainerItemInfo(bag, slot)
+			if info and info.hyperlink then addItem(char, info.hyperlink, info.stackCount) end
+		end
+	end
+	if includeBank then
+		for slot = 1, NUM_BANKGENERIC_SLOTS do
+			local info = C_Container.GetContainerItemInfo(-1, slot)
+			if info and info.hyperlink then addItem(char, info.hyperlink, info.stackCount) end
+		end
+		for bag = NUM_BAG_SLOTS + 1, NUM_BAG_SLOTS + NUM_BANKBAGSLOTS do
+			for slot = 1, C_Container.GetContainerNumSlots(bag) do
+				local info = C_Container.GetContainerItemInfo(bag, slot)
+				if info and info.hyperlink then addItem(char, info.hyperlink, info.stackCount) end
+			end
+		end
+		if IsReagentBankUnlocked() then
+			for slot = 1, C_Container.GetContainerNumSlots(REAGENTBANK_CONTAINER) do
+				local info = C_Container.GetContainerItemInfo(REAGENTBANK_CONTAINER, slot)
+				if info and info.hyperlink then addItem(char, info.hyperlink, info.stackCount) end
+			end
+		end
+	end
+	char.name = UnitName("player")
+	char.realm = GetRealmName()
+	char.class = select(2, UnitClass("player"))
+end
+
+local eventFrame = CreateFrame("Frame")
+AIC.eventFrame = eventFrame
+
+local bankOpen = false
+
+eventFrame:SetScript("OnEvent", function(_, event)
+	if event == "PLAYER_LOGIN" then
+		scanBags(false)
+	elseif event == "BAG_UPDATE_DELAYED" then
+		scanBags(bankOpen)
+	elseif event == "BANKFRAME_OPENED" then
+		bankOpen = true
+		scanBags(true)
+	elseif event == "BANKFRAME_CLOSED" then
+		bankOpen = false
+	elseif event == "PLAYERBANKSLOTS_CHANGED" and bankOpen then
+		scanBags(true)
+	end
+end)
+
+for _, ev in ipairs({ "PLAYER_LOGIN", "BAG_UPDATE_DELAYED", "BANKFRAME_OPENED", "BANKFRAME_CLOSED", "PLAYERBANKSLOTS_CHANGED" }) do
+	eventFrame:RegisterEvent(ev)
+end
+
+function AIC:ToggleWindow()
+	if self.window and self.window.frame:IsShown() then
+		self.window:Hide()
+	else
+		self:CreateWindow()
+	end
+end
+
+function AIC:CreateWindow()
+	if self.window then
+		self.window:Show()
+		return
+	end
+	local frame = AceGUI:Create("Window")
+	frame:SetTitle(L["AltItemSearch"] or "Alt Item Search")
+	frame:SetWidth(500)
+	frame:SetHeight(400)
+	frame:SetLayout("Flow")
+	frame:SetCallback("OnClose", function(widget) widget.frame:Hide() end)
+
+	local edit = AceGUI:Create("EditBox")
+	edit:SetLabel(L["Search"] or SEARCH)
+	edit:SetFullWidth(true)
+	frame:AddChild(edit)
+
+	local scroll = AceGUI:Create("ScrollFrame")
+	scroll:SetLayout("Flow")
+	scroll:SetFullWidth(true)
+	scroll:SetFullHeight(true)
+	frame:AddChild(scroll)
+
+	edit:SetCallback("OnTextChanged", function(_, _, txt) AIC:UpdateResults(txt) end)
+
+	self.window = frame
+	self.editBox = edit
+	self.scroll = scroll
+
+	self:UpdateResults("")
+end
+
+local function matchesQuery(key, count, query)
+	local meta = EnhanceQoL_ItemDB[key]
+	local name = meta and GetItemInfo(meta.link)
+	local id = meta and meta.itemID
+	local itemType = meta and select(6, GetItemInfo(meta.link))
+	query = query and strlower(query) or ""
+	if query == "" then return true end
+	if name and strlower(name):find(query, 1, true) then return true end
+	if id and tostring(id) == query then return true end
+	if itemType and strlower(itemType):find(query, 1, true) then return true end
+	return false
+end
+
+function AIC:UpdateResults(query)
+	local scroll = self.scroll
+	if not scroll then return end
+	scroll:ReleaseChildren()
+	query = query or ""
+	for _, char in pairs(EnhanceQoL_ItemCache or {}) do
+		local items = {}
+		for key, count in pairs(char.items or {}) do
+			if matchesQuery(key, count, query) then table.insert(items, { key = key, count = count }) end
+		end
+		if #items > 0 then
+			table.sort(items, function(a, b)
+				local na = (EnhanceQoL_ItemDB[a.key] and GetItemInfo(EnhanceQoL_ItemDB[a.key].link)) or ""
+				local nb = (EnhanceQoL_ItemDB[b.key] and GetItemInfo(EnhanceQoL_ItemDB[b.key].link)) or ""
+				return na < nb
+			end)
+			local heading = AceGUI:Create("Heading")
+			local displayName = char.name
+			if char.realm ~= GetRealmName() then displayName = displayName .. "-" .. char.realm end
+			heading:SetText(displayName)
+			heading:SetFullWidth(true)
+			scroll:AddChild(heading)
+			local group = AceGUI:Create("SimpleGroup")
+			group:SetLayout("Flow")
+			group:SetFullWidth(true)
+			scroll:AddChild(group)
+			for _, info in ipairs(items) do
+				local meta = EnhanceQoL_ItemDB[info.key]
+				if meta then
+					local icon = AceGUI:Create("Icon")
+					icon:SetImage(select(10, GetItemInfo(meta.link)) or "")
+					icon:SetImageSize(32, 32)
+					local itemName = GetItemInfo(meta.link) or "?"
+					icon:SetLabel(string.format("%s x%d", itemName, info.count))
+					icon:SetRelativeWidth(0.15)
+					icon:SetCallback("OnEnter", function()
+						GameTooltip:SetOwner(icon.frame, "ANCHOR_RIGHT")
+						GameTooltip:SetHyperlink(meta.link)
+						GameTooltip:Show()
+					end)
+					icon:SetCallback("OnLeave", function() GameTooltip:Hide() end)
+					group:AddChild(icon)
+				end
+			end
+		end
+	end
+end
+
+SLASH_EQOLALTITEMS1 = "/eqolitems"
+SlashCmdList["EQOLALTITEMS"] = function() AIC:ToggleWindow() end

--- a/EnhanceQoLTooltip/EnhanceQoLTooltip.lua
+++ b/EnhanceQoLTooltip/EnhanceQoLTooltip.lua
@@ -268,12 +268,12 @@ local function checkItem(tooltip, id, name)
 			tooltip:AddDoubleLine(name, id)
 		end
 	end
-	if addon.db["TooltipShowItemCount"] then
-		if id then
-			local rBankCount = CheckReagentBankCount(id)
-			local bagCount = C_Item.GetItemCount(id)
-			local bankCount = C_Item.GetItemCount(id, true)
-			local totalCount = rBankCount + bankCount
+        if addon.db["TooltipShowItemCount"] then
+                if id then
+                        local rBankCount = CheckReagentBankCount(id)
+                        local bagCount = C_Item.GetItemCount(id)
+                        local bankCount = C_Item.GetItemCount(id, true)
+                        local totalCount = rBankCount + bankCount
 
 			if addon.db["TooltipShowSeperateItemCount"] then
 				if bagCount > 0 then
@@ -283,11 +283,28 @@ local function checkItem(tooltip, id, name)
 				if bankCount > 0 then tooltip:AddDoubleLine(L["Bank"], bankCount) end
 				if rBankCount > 0 then tooltip:AddDoubleLine(L["Reagentbank"], rBankCount) end
 			else
-				tooltip:AddDoubleLine(L["Itemcount"], totalCount)
-			end
-		end
-	end
-	if addon.db["TooltipItemHideType"] == 1 then return end -- only hide when ON
+                                tooltip:AddDoubleLine(L["Itemcount"], totalCount)
+                        end
+                end
+        end
+        if addon.db["showAltItemCountTooltip"] and EnhanceQoL_ItemCache then
+                local playerGUID = UnitGUID("player")
+                local any = false
+                for guid, data in pairs(EnhanceQoL_ItemCache) do
+                        if guid ~= playerGUID and data.itemsByID and data.itemsByID[id] then
+                                if not any then
+                                        tooltip:AddLine(" ")
+                                        any = true
+                                end
+                                local col = (CUSTOM_CLASS_COLORS or RAID_CLASS_COLORS)[data.class] or { r = 1, g = 1, b = 1 }
+                                local name = data.name
+                                if data.realm and data.realm ~= GetRealmName() then name = name .. "-" .. data.realm end
+                                local disp = string.format("|cff%02x%02x%02x%s|r", col.r * 255, col.g * 255, col.b * 255, name)
+                                tooltip:AddDoubleLine(disp, data.itemsByID[id])
+                        end
+                end
+        end
+        if addon.db["TooltipItemHideType"] == 1 then return end -- only hide when ON
 	if addon.db["TooltipItemHideInDungeon"] and select(1, IsInInstance()) == false then return end -- only hide in dungeons
 	if addon.db["TooltipItemHideInCombat"] and UnitAffectingCombat("player") == false then return end -- only hide in combat
 	tooltip:Hide()
@@ -416,8 +433,9 @@ local function addItemFrame(container)
 		{ text = L["TooltipItemHideInCombat"], var = "TooltipItemHideInCombat" },
 		{ text = L["TooltipItemHideInDungeon"], var = "TooltipItemHideInDungeon" },
 		{ text = L["TooltipShowItemID"], var = "TooltipShowItemID" },
-		{ text = L["TooltipShowItemCount"], var = "TooltipShowItemCount" },
-		{ text = L["TooltipShowSeperateItemCount"], var = "TooltipShowSeperateItemCount" },
+                { text = L["TooltipShowItemCount"], var = "TooltipShowItemCount" },
+                { text = L["TooltipShowSeperateItemCount"], var = "TooltipShowSeperateItemCount" },
+                { text = L["TooltipShowAltItemCount"], var = "showAltItemCountTooltip" },
 	}
 
 	table.sort(data, function(a, b) return a.text < b.text end)

--- a/EnhanceQoLTooltip/Init.lua
+++ b/EnhanceQoLTooltip/Init.lua
@@ -28,6 +28,7 @@ addon.functions.InitDBValue("TooltipItemHideType", 1)
 addon.functions.InitDBValue("TooltipItemHideInCombat", false)
 addon.functions.InitDBValue("TooltipItemHideInDungeon", false)
 addon.functions.InitDBValue("TooltipShowItemID", false)
+addon.functions.InitDBValue("showAltItemCountTooltip", false)
 
 -- Buff
 addon.functions.InitDBValue("TooltipBuffHideType", 1)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ English • German • French • Spanish • Italian • Russian • Korean •
 *   Use `/way` to drop a map pin from the Bag Filter search.
 *   Hideable Bag Bar (mouse-over).
 *   Money tracker – total gold for all characters in one tooltip.
-*   Alt-inventory cache – counts how many of each item your alts own.
+*   Alt-inventory cache – counts items across characters via a central item database and offers a `/eqolitems` search window that lists item names and counts.
 
 ### Character & Inspect
 

--- a/docs/OptionsReference.md
+++ b/docs/OptionsReference.md
@@ -24,6 +24,8 @@ This document lists the checkboxes found in EnhanceQoL.lua and briefly explains 
 - **Display ilvl on equipment in all bags** (Display ilvl on equipment in all bags).
 - **Enable item filter in bags** (Enable item filter in bags – drag with <kbd>Shift</kbd> to move).
 - **Enable money tracker** (Enable to track your money across all characters): track gold across all characters.
+- **Enable alt item tracker** (Track items across all characters via a central database and open the search window. Results show item names and counts).
+- If the alt tracker is enabled: **Show alt item counts in tooltips** (Display per-character item counts in item tooltips).
 - **Display item level on the Bank Frame** (Display item level on the Bank Frame).
 - **Display bind type on bag items** (Display %s (BoE), %s (WuE), and %s (WB) as an addition to item level on items).
 - **Fade profession quality icons during search** (Fade profession quality icons during search and filtering).


### PR DESCRIPTION
## Summary
- improve alt item search results by showing item names next to each icon
- clarify documentation for the feature

## Testing
- `luacheck .`
- `stylua EnhanceQoL/Submodules/AltItemCache.lua`


------
https://chatgpt.com/codex/tasks/task_e_683e0340f37c8329996eabedf10da1ef