### PR TITLE
Add Ignore List options with channel filtering

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -2333,6 +2333,26 @@ local function addMapFrame(container)
 	groupCore:AddChild(cbElement)
 end
 
+local function addIgnoreFrame(container)
+	local wrapper = addon.functions.createContainer("SimpleGroup", "Flow")
+	container:AddChild(wrapper)
+
+	local groupCore = addon.functions.createContainer("InlineGroup", "List")
+	wrapper:AddChild(groupCore)
+
+	local data = {
+		{ var = "enableExtendedIgnore", text = L["enableExtendedIgnore"] },
+		{ var = "ignoreFilterYell", text = L["ignoreFilterYell"] },
+		{ var = "ignoreFilterEmote", text = L["ignoreFilterEmote"] },
+		{ var = "ignoreFilterSay", text = L["ignoreFilterSay"] },
+	}
+
+	for _, cbData in ipairs(data) do
+		local cb = addon.functions.createCheckboxAce(cbData.text, addon.db[cbData.var], function(self, _, value) addon.db[cbData.var] = value end)
+		groupCore:AddChild(cb)
+	end
+end
+
 local function updateBankButtonInfo()
 	if not addon.db["showIlvlOnBankFrame"] then return end
 
@@ -2762,6 +2782,13 @@ end
 local function initMap()
 	addon.functions.InitDBValue("enableWayCommand", false)
 	if addon.db["enableWayCommand"] then addon.functions.registerWayCommand() end
+end
+
+local function initIgnoreList()
+	addon.functions.InitDBValue("enableExtendedIgnore", false)
+	addon.functions.InitDBValue("ignoreFilterYell", false)
+	addon.functions.InitDBValue("ignoreFilterEmote", false)
+	addon.functions.InitDBValue("ignoreFilterSay", false)
 end
 
 local function initUI()
@@ -3560,6 +3587,10 @@ local function CreateUI()
 		},
 	})
 	table.insert(addon.treeGroupData, {
+		value = "ignore",
+		text = L["Ignore List"],
+	})
+	table.insert(addon.treeGroupData, {
 		value = "profiles",
 		text = L["Profiles"],
 	})
@@ -3598,6 +3629,8 @@ local function CreateUI()
 			addMinimapFrame(container)
 		elseif group == "general\001map" then
 			addMapFrame(container)
+		elseif group == "ignore" then
+			addIgnoreFrame(container)
 		elseif group == "profiles" then
 			local sub = AceGUI:Create("SimpleGroup")
 			sub:SetFullWidth(true)
@@ -3624,6 +3657,7 @@ local function CreateUI()
 	end)
 	addon.treeGroup:SetStatusTable(addon.variables.statusTable)
 	addon.variables.statusTable.groups["general\001ui"] = true
+	addon.variables.statusTable.groups["ignore"] = true
 	frame:AddChild(addon.treeGroup)
 
 	-- Select the first group by default
@@ -3790,6 +3824,7 @@ local function setAllHooks()
 	initUnitFrame()
 	initChatFrame()
 	initMap()
+	initIgnoreList()
 	initBagsFrame()
 end
 

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -206,3 +206,8 @@ L["persistAuctionHouseFilter"] = "Remember Auction House filters for this sessio
 
 L["Excluded NPCs"] = "Excluded NPCs"
 L["hideDynamicFlightBar"] = "Hide %s Vigor bar while on the ground"
+L["Ignore List"] = "Ignore List"
+L["enableExtendedIgnore"] = "Enable extended ignore"
+L["ignoreFilterYell"] = "Filter YELL channel"
+L["ignoreFilterEmote"] = "Filter EMOTE channel"
+L["ignoreFilterSay"] = "Filter SAY channel"

--- a/EnhanceQoL/Submodules/IgnoreList/Core.lua
+++ b/EnhanceQoL/Submodules/IgnoreList/Core.lua
@@ -1,9 +1,9 @@
 local parentAddonName = "EnhanceQoL"
 local addonName, addon = ...
 if _G[parentAddonName] then
-addon = _G[parentAddonName]
+	addon = _G[parentAddonName]
 else
-error(parentAddonName .. " is not loaded")
+	error(parentAddonName .. " is not loaded")
 end
 
 local IgnoreList = addon.IgnoreList or {}
@@ -13,31 +13,29 @@ addon.IgnoreDB = EnhanceQoL_IgnoreDB
 IgnoreList.db = EnhanceQoL_IgnoreDB
 
 local function normalize(name)
-if not name then return end
-name = name:gsub("%s", "")
-if not name:find("-") then
-local realm = GetNormalizedRealmName()
-if realm then name = name .. "-" .. realm end
-end
-return name:lower()
+	if not name then return end
+	name = name:gsub("%s", "")
+	if not name:find("-") then
+		local realm = GetNormalizedRealmName()
+		if realm then name = name .. "-" .. realm end
+	end
+	return name:lower()
 end
 
 local function addEntry(name, note)
-EnhanceQoL_IgnoreDB[name] = {
-name = name,
-faction = UnitFactionGroup("player"),
-time = time(),
-note = note,
-}
+	EnhanceQoL_IgnoreDB[name] = {
+		name = name,
+		faction = UnitFactionGroup("player"),
+		time = time(),
+		note = note,
+	}
 end
 
-local function removeEntry(name)
-EnhanceQoL_IgnoreDB[name] = nil
-end
+local function removeEntry(name) EnhanceQoL_IgnoreDB[name] = nil end
 
 function IgnoreList:IsIgnored(name)
-name = normalize(name)
-return name and EnhanceQoL_IgnoreDB[name]
+	name = normalize(name)
+	return name and EnhanceQoL_IgnoreDB[name]
 end
 
 IgnoreList.origAdd = C_FriendList.AddIgnore or AddIgnore
@@ -46,78 +44,82 @@ IgnoreList.origToggle = C_FriendList.AddOrDelIgnore or AddOrDelIgnore
 local maxSize = C_FriendList.GetMaxNumIgnored and C_FriendList.GetMaxNumIgnored() or 50
 
 local function performAdd(name, note)
-name = normalize(name)
-if not name then return end
-addEntry(name, note)
-if C_FriendList.GetNumIgnores and C_FriendList.GetNumIgnores() < maxSize then
-if IgnoreList.origAdd then IgnoreList.origAdd(name) end
-end
+	name = normalize(name)
+	if not name then return end
+	addEntry(name, note)
+	if C_FriendList.GetNumIgnores and C_FriendList.GetNumIgnores() < maxSize then
+		if IgnoreList.origAdd then IgnoreList.origAdd(name) end
+	end
 end
 
 IgnoreList.performAdd = performAdd
-function IgnoreList:AddIgnore(name)
-StaticPopup_Show("EQOL_ADD_IGNORE_NOTE", nil, nil, name)
-end
+function IgnoreList:AddIgnore(name) StaticPopup_Show("EQOL_ADD_IGNORE_NOTE", nil, nil, name) end
 
 function IgnoreList:DelIgnore(name)
-name = normalize(name)
-if not name then return end
-removeEntry(name)
-if IgnoreList.origDel then IgnoreList.origDel(name) end
+	name = normalize(name)
+	if not name then return end
+	removeEntry(name)
+	if IgnoreList.origDel then IgnoreList.origDel(name) end
 end
 
 function IgnoreList:AddOrDelIgnore(name)
-if self:IsIgnored(name) then
-self:DelIgnore(name)
-else
-self:AddIgnore(name)
+	if self:IsIgnored(name) then
+		self:DelIgnore(name)
+	else
+		self:AddIgnore(name)
+	end
 end
-end
-
 
 local shown = {}
 local frame = CreateFrame("Frame")
 local function checkGroup()
-local members = {}
-local prefix = IsInRaid() and "raid" or "party"
-for i = 1, GetNumGroupMembers() do
-local unit = prefix .. i
-local n = GetUnitName(unit, true)
-n = normalize(n)
-if n and IgnoreList:IsIgnored(n) and not shown[n] then
-shown[n] = true
-table.insert(members, n)
-end
-end
-if #members > 0 then
-StaticPopup_Show("EQOL_IGNORELIST_GROUP", table.concat(members, ", "))
-end
+	if not addon.db or not addon.db.enableExtendedIgnore then return end
+	local members = {}
+	local prefix = IsInRaid() and "raid" or "party"
+	for i = 1, GetNumGroupMembers() do
+		local unit = prefix .. i
+		local n = GetUnitName(unit, true)
+		n = normalize(n)
+		if n and IgnoreList:IsIgnored(n) and not shown[n] then
+			shown[n] = true
+			table.insert(members, n)
+		end
+	end
+	if #members > 0 then StaticPopup_Show("EQOL_IGNORELIST_GROUP", table.concat(members, ", ")) end
 end
 
 frame:SetScript("OnEvent", function(_, event)
-if event == "GROUP_JOINED" then
-wipe(shown)
-checkGroup()
-elseif event == "GROUP_ROSTER_UPDATE" then
-checkGroup()
-end
+	if event == "GROUP_JOINED" then
+		wipe(shown)
+		checkGroup()
+	elseif event == "GROUP_ROSTER_UPDATE" then
+		checkGroup()
+	end
 end)
 frame:RegisterEvent("GROUP_JOINED")
 frame:RegisterEvent("GROUP_ROSTER_UPDATE")
 
-
-local function whisperFilter(_, _, _, sender)
-if IgnoreList:IsIgnored(sender) then return true end
+local function chatFilter(_, event, _, sender)
+	if not addon.db or not addon.db.enableExtendedIgnore then return end
+	if not IgnoreList:IsIgnored(sender) then return end
+	if event == "CHAT_MSG_WHISPER" or event == "CHAT_MSG_BN_WHISPER" then return true end
+	if event == "CHAT_MSG_YELL" and addon.db.ignoreFilterYell then return true end
+	if (event == "CHAT_MSG_EMOTE" or event == "CHAT_MSG_TEXT_EMOTE") and addon.db.ignoreFilterEmote then return true end
+	if event == "CHAT_MSG_SAY" and addon.db.ignoreFilterSay then return true end
 end
-ChatFrame_AddMessageEventFilter("CHAT_MSG_WHISPER", whisperFilter)
-ChatFrame_AddMessageEventFilter("CHAT_MSG_BN_WHISPER", whisperFilter)
+ChatFrame_AddMessageEventFilter("CHAT_MSG_WHISPER", chatFilter)
+ChatFrame_AddMessageEventFilter("CHAT_MSG_BN_WHISPER", chatFilter)
+ChatFrame_AddMessageEventFilter("CHAT_MSG_YELL", chatFilter)
+ChatFrame_AddMessageEventFilter("CHAT_MSG_EMOTE", chatFilter)
+ChatFrame_AddMessageEventFilter("CHAT_MSG_TEXT_EMOTE", chatFilter)
+ChatFrame_AddMessageEventFilter("CHAT_MSG_SAY", chatFilter)
 
 if addon.ChatIM and addon.ChatIM.AddMessage then
-local orig = addon.ChatIM.AddMessage
-function addon.ChatIM:AddMessage(partner, text, outbound, isBN, bnetID)
-if not outbound and IgnoreList:IsIgnored(partner) then return end
-orig(self, partner, text, outbound, isBN, bnetID)
-end
+	local orig = addon.ChatIM.AddMessage
+	function addon.ChatIM:AddMessage(partner, text, outbound, isBN, bnetID)
+		if not outbound and IgnoreList:IsIgnored(partner) then return end
+		orig(self, partner, text, outbound, isBN, bnetID)
+	end
 end
 
 C_FriendList.AddIgnore = function(name) IgnoreList:AddIgnore(name) end


### PR DESCRIPTION
## Summary
- add an options panel for Ignore List
- offer toggles for extended ignore and channel filtering
- gate Ignore List filters behind the new option

## Testing
- `luacheck EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Submodules/IgnoreList/Core.lua EnhanceQoL/Locales/enUS.lua`

------
https://chatgpt.com/codex/tasks/task_e_68456b2046b08329869378ffe202425b