### PR TITLE
Add hide player frame option

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -1597,16 +1597,25 @@ local function addPartyFrame(container)
 				end
 			end,
 		},
-		{
-			parent = "",
-			var = "showPartyFrameInSoloContent",
-			type = "CheckBox",
-			callback = function(self, _, value)
-				addon.db["showPartyFrameInSoloContent"] = value
-				addon.variables.requireReload = true
-			end,
-		},
-	}
+                {
+                        parent = "",
+                        var = "showPartyFrameInSoloContent",
+                        type = "CheckBox",
+                        callback = function(self, _, value)
+                                addon.db["showPartyFrameInSoloContent"] = value
+                                addon.variables.requireReload = true
+                        end,
+                },
+                {
+                        parent = "",
+                        var = "hidePlayerFrame",
+                        type = "CheckBox",
+                        callback = function(self, _, value)
+                                addon.db["hidePlayerFrame"] = value
+                                addon.functions.togglePlayerFrame(addon.db["hidePlayerFrame"])
+                        end,
+                },
+        }
 
 	if addon.db["autoAcceptGroupInvite"] == true then
 		table.insert(data, {
@@ -2651,13 +2660,26 @@ local function initMisc()
 end
 
 local function initUnitFrame()
-	addon.functions.InitDBValue("hideHitIndicatorPlayer", false)
-	addon.functions.InitDBValue("hideHitIndicatorPet", false)
-	if addon.db["hideHitIndicatorPlayer"] then PlayerFrame.PlayerFrameContent.PlayerFrameContentMain.HitIndicator:Hide() end
+        addon.functions.InitDBValue("hideHitIndicatorPlayer", false)
+        addon.functions.InitDBValue("hideHitIndicatorPet", false)
+        addon.functions.InitDBValue("hidePlayerFrame", false)
+        if addon.db["hideHitIndicatorPlayer"] then PlayerFrame.PlayerFrameContent.PlayerFrameContentMain.HitIndicator:Hide() end
 
-	if PetHitIndicator then hooksecurefunc(PetHitIndicator, "Show", function(self)
-		if addon.db["hideHitIndicatorPet"] then PetHitIndicator:Hide() end
-	end) end
+        if PetHitIndicator then hooksecurefunc(PetHitIndicator, "Show", function(self)
+                if addon.db["hideHitIndicatorPet"] then PetHitIndicator:Hide() end
+        end) end
+
+        function addon.functions.togglePlayerFrame(value)
+                if value then
+                        PlayerFrame:Hide()
+                else
+                        PlayerFrame:Show()
+                end
+        end
+        PlayerFrame:HookScript("OnShow", function(self)
+                if addon.db["hidePlayerFrame"] then self:Hide() end
+        end)
+        addon.functions.togglePlayerFrame(addon.db["hidePlayerFrame"])
 
 	for _, cbData in ipairs(addon.variables.unitFrameNames) do
 		if cbData.var and cbData.name then

--- a/EnhanceQoL/Init.lua
+++ b/EnhanceQoL/Init.lua
@@ -1,6 +1,7 @@
 local addonName, addon = ...
 _G[addonName] = addon
 addon.saveVariables = {} -- Cross-Module variables for DB Save
+addon.saveVariables["hidePlayerFrame"] = false -- Default for hiding the Player Frame
 addon.gossip = {}
 addon.gossip.variables = {}
 addon.variables = {}

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -146,6 +146,7 @@ L["autoAcceptGroupInviteOptions"] = "Accept invites from..."
 
 L["showLeaderIconRaidFrame"] = "Show leader icon on raid-style party frames"
 L["showPartyFrameInSoloContent"] = "Show Party Frames in Solo Content"
+L["hidePlayerFrame"] = "Hide Player Frame"
 
 L["ActionbarHideExplain"] = 'Set the action bar to hidden and show on mouseover. This works only when your Action Bar is set to "%s" and "%s" in %s'
 

--- a/docs/OptionsReference.md
+++ b/docs/OptionsReference.md
@@ -72,6 +72,7 @@ Each action bar can be set to appear only on mouseover:
   - **Friends** (Friends).
 - **Show leader icon on raid-style party frames** (Show leader icon on raid-style party frames).
 - **Show Party Frames in Solo Content** (Show Party Frames in Solo Content).
+- **Hide Player Frame** (Hide Player Frame).
 
 ## Dungeon / Mythic+
 - **Hide the group finder text 'Your group is currently forming'** (Hide the group finder text "Your group is currently forming").


### PR DESCRIPTION
## Summary
- add new saved variable `hidePlayerFrame`
- implement player frame toggle and persistence
- expose checkbox option to hide the player frame
- add English locale string
- document the new option in OptionsReference

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849e2a6a17883299f82e5181a9996eb