### PR TITLE
Delay buff tracker missing check on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [3.20.1] – 2025-06-12  
+## [3.20.2] – 2025-06-13
+### 🐛 Fixed
+- Fixed the Buff Tracker mistakenly triggering "missing" alerts on login by delaying the initial scan.
+
+## [3.20.1] – 2025-06-12
 ### 🐛 Fixed
 - Fixed an issue in groups with **Hide buffs on raid frames**
 

--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -291,7 +291,11 @@ eventFrame:SetScript("OnEvent", function(_, event, unit)
 				anchor:Hide()
 			end
 		end
-		if event == "PLAYER_LOGIN" then addon.Aura.functions.BuildSoundTable() end
+		if event == "PLAYER_LOGIN" then
+			addon.Aura.functions.BuildSoundTable()
+			C_Timer.After(1, scanBuffs)
+			return
+		end
 	end
 	scanBuffs()
 end)
@@ -347,13 +351,11 @@ local function openBuffConfig(catId, id)
 		addon.db["buffTrackerSounds"][catId] = addon.db["buffTrackerSounds"][catId] or {}
 		addon.db["buffTrackerSoundsEnabled"][catId] = addon.db["buffTrackerSoundsEnabled"][catId] or {}
 
-               local cbElement = addon.functions.createCheckboxAce(
-                       L["buffTrackerSoundsEnabled"],
-                       addon.db["buffTrackerSoundsEnabled"][catId][id],
-                       function(_, _, val)
-                               addon.db["buffTrackerSoundsEnabled"][catId][id] = val
-                       end
-               )
+		local cbElement = addon.functions.createCheckboxAce(
+			L["buffTrackerSoundsEnabled"],
+			addon.db["buffTrackerSoundsEnabled"][catId][id],
+			function(_, _, val) addon.db["buffTrackerSoundsEnabled"][catId][id] = val end
+		)
 		frame:AddChild(cbElement)
 
 		local soundList = {}
@@ -371,14 +373,10 @@ local function openBuffConfig(catId, id)
 
 		frame:AddChild(dropSound)
 
-               local cbMissing = addon.functions.createCheckboxAce(
-                       L["buffTrackerShowWhenMissing"],
-                       buff.showWhenMissing,
-                       function(_, _, val)
-                               buff.showWhenMissing = val
-                               scanBuffs()
-                       end
-               )
+		local cbMissing = addon.functions.createCheckboxAce(L["buffTrackerShowWhenMissing"], buff.showWhenMissing, function(_, _, val)
+			buff.showWhenMissing = val
+			scanBuffs()
+		end)
 		frame:AddChild(cbMissing)
 
 		-- alternative spell ids


### PR DESCRIPTION
## Summary
- delay missing-buff scan for buff tracker on login to prevent false alerts
- document fix in changelog

## Testing
- `stylua EnhanceQoLAura/BuffTracker.lua`
- `luacheck EnhanceQoLAura/BuffTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_684e645a74e48329b9d78fe7f725eca4