### PR TITLE
Fix LFG accessibility background

### DIFF
--- a/EnhanceQoLAccessibility/EnhanceQoLAccessibility.lua
+++ b/EnhanceQoLAccessibility/EnhanceQoLAccessibility.lua
@@ -43,16 +43,14 @@ end
 
 local function updateLFGBackground()
 	if not LFGListFrame or not LFGListFrame.SearchPanel then return end
-	local c = addon.db["lfgBackgroundColor"] or { r = 0, g = 0, b = 0 }
+	local c
 	if addon.db["lfgAccessibilityEnabled"] then
-		colorRegions(LFGListFrame.SearchPanel, c)
-		if LFGListFrame.SearchPanel.ScrollBox then colorRegions(LFGListFrame.SearchPanel.ScrollBox, c) end
+		c = { r = 0, g = 0, b = 0 }
 	else
 		c = { r = 1, g = 1, b = 1 }
-		colorRegions(LFGListFrame.SearchPanel, c)
-		if LFGListFrame.SearchPanel.ScrollBox then colorRegions(LFGListFrame.SearchPanel.ScrollBox, c) end
-
 	end
+	colorRegions(LFGListFrame.SearchPanel, c)
+	if LFGListFrame.SearchPanel.ScrollBox then colorRegions(LFGListFrame.SearchPanel.ScrollBox, c) end
 end
 
 local function addFontFrame(container)
@@ -80,7 +78,6 @@ local function applyListingColor(entry)
 	local name = addon.db["lfgListingColorCustom"]
 	if entry.ActivityName and act then entry.ActivityName:SetTextColor(act.r, act.g, act.b) end
 	if entry.Name and name then entry.Name:SetTextColor(name.r, name.g, name.b) end
-
 end
 
 hooksecurefunc("LFGListSearchEntry_Update", applyListingColor)
@@ -118,16 +115,6 @@ local function addLFGFrame(container)
 	cp2:SetColor(c2.r, c2.g, c2.b)
 	cp2:SetCallback("OnValueChanged", function(widget, event, r, g, b) addon.db["lfgListingColorCustom"] = { r = r, g = g, b = b } end)
 	group:AddChild(cp2)
-
-	local cpBg = AceGUI:Create("ColorPicker")
-	cpBg:SetLabel(L["Listing background color"])
-	local cBg = addon.db["lfgBackgroundColor"] or { r = 0, g = 0, b = 0 }
-	cpBg:SetColor(cBg.r, cBg.g, cBg.b)
-	cpBg:SetCallback("OnValueChanged", function(widget, event, r, g, b)
-		addon.db["lfgBackgroundColor"] = { r = r, g = g, b = b }
-		updateLFGBackground()
-	end)
-	group:AddChild(cpBg)
 end
 
 addon.functions.addToTree(nil, {

--- a/EnhanceQoLAccessibility/Init.lua
+++ b/EnhanceQoLAccessibility/Init.lua
@@ -15,5 +15,3 @@ addon.functions.InitDBValue("lfgListingColor", { r = 1, g = 1, b = 1 })
 addon.functions.InitDBValue("lfgAccessibilityEnabled", true)
 addon.functions.InitDBValue("lfgListingColorActivity", { r = 1, g = 1, b = 1 })
 addon.functions.InitDBValue("lfgListingColorCustom", { r = 1, g = 1, b = 1 })
-
-addon.functions.InitDBValue("lfgBackgroundColor", { r = 0, g = 0, b = 0 })


### PR DESCRIPTION
## Summary
- remove saved variable for LFG background color
- drop background color picker from the Accessibility options
- apply a constant background color when LFG tweaks are enabled

## Testing
- `luacheck EnhanceQoLAccessibility/Init.lua EnhanceQoLAccessibility/EnhanceQoLAccessibility.lua`
- `stylua EnhanceQoLAccessibility/Init.lua EnhanceQoLAccessibility/EnhanceQoLAccessibility.lua`


------
https://chatgpt.com/codex/tasks/task_e_6850ea0a6ad483299abe2f8b38d07afe