### PR TITLE
Apply font settings across interface

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -47,7 +47,10 @@ local function checkBagIgnoreJunk()
 				whileDead = true,
 				hideOnEscape = true,
 				preferredIndex = 3,
-				OnShow = function(self) self:SetFrameStrata("TOOLTIP") end,
+                               OnShow = function(self)
+                                       self:SetFrameStrata("TOOLTIP")
+                                       addon.functions.applyPopupFonts(self)
+                               end,
 			}
 			StaticPopup_Show("SellJunkIgnoredBag")
 		end
@@ -1095,16 +1098,17 @@ local function addChatFrame(container)
 		local btnDelete = addon.functions.createButtonAce(L["ChatIMHistoryDelete"], 140, function()
 			local target = dropHistory:GetValue()
 			if not target then return end
-			StaticPopupDialogs["EQOL_DELETE_IM_HISTORY"] = StaticPopupDialogs["EQOL_DELETE_IM_HISTORY"]
-				or {
-					text = L["ChatIMHistoryDeleteConfirm"],
-					button1 = YES,
-					button2 = CANCEL,
-					timeout = 0,
-					whileDead = true,
-					hideOnEscape = true,
-					preferredIndex = 3,
-				}
+                       StaticPopupDialogs["EQOL_DELETE_IM_HISTORY"] = StaticPopupDialogs["EQOL_DELETE_IM_HISTORY"]
+                               or {
+                                        text = L["ChatIMHistoryDeleteConfirm"],
+                                        button1 = YES,
+                                        button2 = CANCEL,
+                                        timeout = 0,
+                                        whileDead = true,
+                                        hideOnEscape = true,
+                                        preferredIndex = 3,
+                                        OnShow = function(self) addon.functions.applyPopupFonts(self) end,
+                               }
 			StaticPopupDialogs["EQOL_DELETE_IM_HISTORY"].OnAccept = function()
 				EnhanceQoL_IMHistory[target] = nil
 				if addon.ChatIM and addon.ChatIM.history then addon.ChatIM.history[target] = nil end
@@ -1115,16 +1119,17 @@ local function addChatFrame(container)
 		end)
 
 		local btnClear = addon.functions.createButtonAce(L["ChatIMHistoryClearAll"], 140, function()
-			StaticPopupDialogs["EQOL_CLEAR_IM_HISTORY"] = StaticPopupDialogs["EQOL_CLEAR_IM_HISTORY"]
-				or {
-					text = L["ChatIMHistoryClearConfirm"],
-					button1 = YES,
-					button2 = CANCEL,
-					timeout = 0,
-					whileDead = true,
-					hideOnEscape = true,
-					preferredIndex = 3,
-				}
+                       StaticPopupDialogs["EQOL_CLEAR_IM_HISTORY"] = StaticPopupDialogs["EQOL_CLEAR_IM_HISTORY"]
+                               or {
+                                        text = L["ChatIMHistoryClearConfirm"],
+                                        button1 = YES,
+                                        button2 = CANCEL,
+                                        timeout = 0,
+                                        whileDead = true,
+                                        hideOnEscape = true,
+                                        preferredIndex = 3,
+                                        OnShow = function(self) addon.functions.applyPopupFonts(self) end,
+                               }
 			StaticPopupDialogs["EQOL_CLEAR_IM_HISTORY"].OnAccept = function()
 				wipe(EnhanceQoL_IMHistory)
 				if addon.ChatIM then addon.ChatIM.history = EnhanceQoL_IMHistory end

--- a/EnhanceQoL/General/functions.lua
+++ b/EnhanceQoL/General/functions.lua
@@ -13,6 +13,18 @@ local IsEquippableItem = C_Item.IsEquippableItem
 local UnitInParty = UnitInParty
 local UnitInRaid = UnitInRaid
 
+function addon.functions.getLocaleDefaultFont()
+       local locale = GAME_LOCALE or GetLocale()
+       if locale == "ruRU" then
+               return "Fonts\\ARIALN.TTF"
+       elseif locale == "koKR" then
+               return "Fonts\\2002.ttf"
+       elseif locale == "zhTW" or locale == "zhCN" then
+               return "Fonts\\ARKai_T.ttf"
+       end
+       return "Fonts\\FRIZQT__.TTF"
+end
+
 function addon.functions.InitDBValue(key, defaultValue)
 	if addon.db[key] == nil then addon.db[key] = defaultValue end
 end
@@ -210,6 +222,18 @@ function addon.functions.updateTreeGroupFonts(tree)
                        btn.text:SetFont(addon.variables.defaultFont, 14, "OUTLINE")
                end
        end
+end
+
+function addon.functions.applyPopupFonts(popup)
+       if not popup then return end
+       if popup.text and popup.text.SetFont then popup.text:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
+       if popup.button1 and popup.button1.GetFontString and popup.button1:GetFontString() then
+               popup.button1:GetFontString():SetFont(addon.variables.defaultFont, 14, "OUTLINE")
+       end
+       if popup.button2 and popup.button2.GetFontString and popup.button2:GetFontString() then
+               popup.button2:GetFontString():SetFont(addon.variables.defaultFont, 14, "OUTLINE")
+       end
+       if popup.editBox and popup.editBox.SetFont then popup.editBox:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
 end
 
 function addon.functions.createWrapperData(data, container, L)

--- a/EnhanceQoL/Submodules/ChatIM/UI.lua
+++ b/EnhanceQoL/Submodules/ChatIM/UI.lua
@@ -101,11 +101,12 @@ StaticPopupDialogs["EQOL_URL_COPY"] = {
 	whileDead = true,
 	hideOnEscape = true,
 	preferredIndex = 3,
-	OnShow = function(self, data)
-		self.editBox:SetText(data or "")
-		self.editBox:SetFocus()
-		self.editBox:HighlightText()
-	end,
+       OnShow = function(self, data)
+               addon.functions.applyPopupFonts(self)
+               self.editBox:SetText(data or "")
+               self.editBox:SetFocus()
+               self.editBox:HighlightText()
+       end,
 }
 
 StaticPopupDialogs["EQOL_LINK_WARNING"] = {
@@ -116,7 +117,10 @@ StaticPopupDialogs["EQOL_LINK_WARNING"] = {
 	timeout = 0,
 	whileDead = true,
 	hideOnEscape = true,
-	preferredIndex = 3,
+       preferredIndex = 3,
+       OnShow = function(self)
+               addon.functions.applyPopupFonts(self)
+       end,
 }
 
 ChatIM.storage = ChatIM.storage or CreateFrame("Frame")
@@ -293,10 +297,10 @@ function ChatIM:CreateTab(sender, isBN, bnetID, battleTag)
 		if info then battleTag = info.battleTag end
 	end
 
-	local smf = CreateFrame("ScrollingMessageFrame", nil, ChatIM.storage)
-	-- we'll anchor later when the tab becomes active
-	smf:SetAllPoints(ChatIM.storage)
-	smf:SetFontObject(ChatFontNormal)
+       local smf = CreateFrame("ScrollingMessageFrame", nil, ChatIM.storage)
+       -- we'll anchor later when the tab becomes active
+       smf:SetAllPoints(ChatIM.storage)
+       smf:SetFont(addon.variables.defaultFont, 14, "OUTLINE")
 	smf:SetJustifyH("LEFT")
 	smf:SetFading(false)
 	smf:SetMaxLines(ChatIM.maxHistoryLines)
@@ -416,10 +420,10 @@ function ChatIM:CreateTab(sender, isBN, bnetID, battleTag)
 		end
 	end
 	-- will be parented/anchored once the tab becomes active
-	local eb = CreateFrame("EditBox", nil, ChatIM.storage, "InputBoxTemplate")
-	eb:SetAutoFocus(false)
-	eb:SetHeight(20)
-	eb:SetFontObject(ChatFontNormal)
+       local eb = CreateFrame("EditBox", nil, ChatIM.storage, "InputBoxTemplate")
+       eb:SetAutoFocus(false)
+       eb:SetHeight(20)
+       eb:SetFont(addon.variables.defaultFont, 14, "OUTLINE")
 	eb:SetScript("OnEditFocusGained", function() ChatIM:UpdateAlpha() end)
 	eb:SetScript("OnEditFocusLost", function()
 		C_Timer.After(5, function() ChatIM:UpdateAlpha() end)
@@ -708,7 +712,7 @@ function ChatIM:HideWindow()
 end
 
 function ChatIM:StartWhisper(target, bnetID, accountTag)
-	if not target then return end
+        if not target then return end
 	if bnetID then
 		self:CreateTab(target, true, bnetID, accountTag)
 	else
@@ -718,5 +722,20 @@ function ChatIM:StartWhisper(target, bnetID, accountTag)
 	if not self.tabGroup then return end
 	self.tabGroup:SelectTab(target)
 	local tab = self.tabs[target]
-	if tab and tab.edit then tab.edit:SetFocus() end
+        if tab and tab.edit then tab.edit:SetFocus() end
+end
+
+function ChatIM:ApplyFonts()
+       if self.widget and self.widget.titletext and self.widget.titletext.SetFont then
+               self.widget.titletext:SetFont(addon.variables.defaultFont, 14, "OUTLINE")
+       end
+       if self.tabGroup and self.tabGroup.titletext and self.tabGroup.titletext.SetFont then
+               self.tabGroup.titletext:SetFont(addon.variables.defaultFont, 14, "OUTLINE")
+       end
+       if self.tabs then
+               for _, tab in pairs(self.tabs) do
+                       if tab.msg and tab.msg.SetFont then tab.msg:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
+                       if tab.edit and tab.edit.SetFont then tab.edit:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
+               end
+       end
 end

--- a/EnhanceQoLAccessibility/EnhanceQoLAccessibility.lua
+++ b/EnhanceQoLAccessibility/EnhanceQoLAccessibility.lua
@@ -60,6 +60,11 @@ local function addFontFrame(container)
 	local group = addon.functions.createContainer("InlineGroup", "List")
 	wrapper:AddChild(group)
 
+	local hint = addon.functions.createLabelAce(L["FontChangeHint"])
+	hint:SetFullWidth(true)
+	group:AddChild(hint)
+	group:AddChild(addon.functions.createSpacerAce())
+
 	-- Build a list that uses the font name for both key and value so the
 	-- dropdown shows the name instead of the font path
 	local fontsList = {}
@@ -67,31 +72,33 @@ local function addFontFrame(container)
 		fontsList[name] = name
 	end
 	local list, order = addon.functions.prepareListForDropdown(fontsList, true)
-       local drop = addon.functions.createDropdownAce(L["Default Font"], list, order, function(self, _, key)
-               addon.db["accessibilityFont"] = key
-               addon.variables.defaultFont = fonts[key]
-               if addon.treeGroup then addon.functions.updateTreeGroupFonts(addon.treeGroup) end
-               if addon.ChatIM and addon.ChatIM.ApplyFonts then addon.ChatIM:ApplyFonts() end
-       end)
+	local drop = addon.functions.createDropdownAce(L["Default Font"], list, order, function(self, _, key)
+		addon.db["accessibilityFont"] = key
+		addon.variables.defaultFont = fonts[key]
+		if addon.treeGroup then addon.functions.updateTreeGroupFonts(addon.treeGroup) end
+		if addon.ChatIM and addon.ChatIM.ApplyFonts then addon.ChatIM:ApplyFonts() end
+		addon.variables.requireReload = true
+	end)
 	drop:SetCallback("OnOpened", function()
 		for _, item in drop.pullout:IterateItems() do
 			item.text:SetFont(fonts[item.userdata.value], 12, "OUTLINE")
 		end
 	end)
-       drop:SetValue(addon.db["accessibilityFont"])
-       drop:SetWidth(250)
-       group:AddChild(drop)
+	drop:SetValue(addon.db["accessibilityFont"])
+	drop:SetWidth(250)
+	group:AddChild(drop)
+	group:AddChild(addon.functions.createSpacerAce())
 
-       local hint = addon.functions.createLabelAce(L["FontChangeHint"])
-       group:AddChild(hint)
-
-       local resetBtn = addon.functions.createButtonAce(L["Reset to default"], nil, function()
-               addon.db["accessibilityFont"] = nil
-               addon.variables.defaultFont = addon.functions.getLocaleDefaultFont()
-               if addon.treeGroup then addon.functions.updateTreeGroupFonts(addon.treeGroup) end
-               if addon.ChatIM and addon.ChatIM.ApplyFonts then addon.ChatIM:ApplyFonts() end
-       end)
-       group:AddChild(resetBtn)
+	local resetBtn = addon.functions.createButtonAce(L["Reset to default"], nil, function()
+		addon.db["accessibilityFont"] = nil
+		addon.variables.defaultFont = addon.functions.getLocaleDefaultFont()
+		if addon.treeGroup then addon.functions.updateTreeGroupFonts(addon.treeGroup) end
+		if addon.ChatIM and addon.ChatIM.ApplyFonts then addon.ChatIM:ApplyFonts() end
+		addon.variables.requireReload = true
+		addon.functions.checkReloadFrame()
+	end)
+	resetBtn:SetWidth(200)
+	group:AddChild(resetBtn)
 end
 
 local function applyListingColor(entry)
@@ -124,17 +131,17 @@ local function addLFGFrame(container)
 
 	group:AddChild(addon.functions.createSpacerAce())
 
-       local cp1 = AceGUI:Create("ColorPicker")
-       cp1:SetLabel(L["Listing activity name color"])
-       if cp1.text and cp1.text.SetFont then cp1.text:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
+	local cp1 = AceGUI:Create("ColorPicker")
+	cp1:SetLabel(L["Listing activity name color"])
+	if cp1.text and cp1.text.SetFont then cp1.text:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
 	local c1 = addon.db["lfgListingColorActivity"] or { r = 1, g = 1, b = 1 }
 	cp1:SetColor(c1.r, c1.g, c1.b)
 	cp1:SetCallback("OnValueChanged", function(widget, event, r, g, b) addon.db["lfgListingColorActivity"] = { r = r, g = g, b = b } end)
 	group:AddChild(cp1)
 
-       local cp2 = AceGUI:Create("ColorPicker")
-       cp2:SetLabel(L["Listing custom text color"])
-       if cp2.text and cp2.text.SetFont then cp2.text:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
+	local cp2 = AceGUI:Create("ColorPicker")
+	cp2:SetLabel(L["Listing custom text color"])
+	if cp2.text and cp2.text.SetFont then cp2.text:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
 	local c2 = addon.db["lfgListingColorCustom"] or { r = 1, g = 1, b = 1 }
 	cp2:SetColor(c2.r, c2.g, c2.b)
 	cp2:SetCallback("OnValueChanged", function(widget, event, r, g, b) addon.db["lfgListingColorCustom"] = { r = r, g = g, b = b } end)

--- a/EnhanceQoLAccessibility/EnhanceQoLAccessibility.lua
+++ b/EnhanceQoLAccessibility/EnhanceQoLAccessibility.lua
@@ -67,19 +67,31 @@ local function addFontFrame(container)
 		fontsList[name] = name
 	end
 	local list, order = addon.functions.prepareListForDropdown(fontsList, true)
-	local drop = addon.functions.createDropdownAce(L["Default Font"], list, order, function(self, _, key)
+       local drop = addon.functions.createDropdownAce(L["Default Font"], list, order, function(self, _, key)
                addon.db["accessibilityFont"] = key
                addon.variables.defaultFont = fonts[key]
                if addon.treeGroup then addon.functions.updateTreeGroupFonts(addon.treeGroup) end
+               if addon.ChatIM and addon.ChatIM.ApplyFonts then addon.ChatIM:ApplyFonts() end
        end)
 	drop:SetCallback("OnOpened", function()
 		for _, item in drop.pullout:IterateItems() do
 			item.text:SetFont(fonts[item.userdata.value], 12, "OUTLINE")
 		end
 	end)
-	drop:SetValue(addon.db["accessibilityFont"])
-	drop:SetWidth(250)
-	group:AddChild(drop)
+       drop:SetValue(addon.db["accessibilityFont"])
+       drop:SetWidth(250)
+       group:AddChild(drop)
+
+       local hint = addon.functions.createLabelAce(L["FontChangeHint"])
+       group:AddChild(hint)
+
+       local resetBtn = addon.functions.createButtonAce(L["Reset to default"], nil, function()
+               addon.db["accessibilityFont"] = nil
+               addon.variables.defaultFont = addon.functions.getLocaleDefaultFont()
+               if addon.treeGroup then addon.functions.updateTreeGroupFonts(addon.treeGroup) end
+               if addon.ChatIM and addon.ChatIM.ApplyFonts then addon.ChatIM:ApplyFonts() end
+       end)
+       group:AddChild(resetBtn)
 end
 
 local function applyListingColor(entry)
@@ -112,15 +124,17 @@ local function addLFGFrame(container)
 
 	group:AddChild(addon.functions.createSpacerAce())
 
-	local cp1 = AceGUI:Create("ColorPicker")
-	cp1:SetLabel(L["Listing activity name color"])
+       local cp1 = AceGUI:Create("ColorPicker")
+       cp1:SetLabel(L["Listing activity name color"])
+       if cp1.text and cp1.text.SetFont then cp1.text:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
 	local c1 = addon.db["lfgListingColorActivity"] or { r = 1, g = 1, b = 1 }
 	cp1:SetColor(c1.r, c1.g, c1.b)
 	cp1:SetCallback("OnValueChanged", function(widget, event, r, g, b) addon.db["lfgListingColorActivity"] = { r = r, g = g, b = b } end)
 	group:AddChild(cp1)
 
-	local cp2 = AceGUI:Create("ColorPicker")
-	cp2:SetLabel(L["Listing custom text color"])
+       local cp2 = AceGUI:Create("ColorPicker")
+       cp2:SetLabel(L["Listing custom text color"])
+       if cp2.text and cp2.text.SetFont then cp2.text:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
 	local c2 = addon.db["lfgListingColorCustom"] or { r = 1, g = 1, b = 1 }
 	cp2:SetColor(c2.r, c2.g, c2.b)
 	cp2:SetCallback("OnValueChanged", function(widget, event, r, g, b) addon.db["lfgListingColorCustom"] = { r = r, g = g, b = b } end)

--- a/EnhanceQoLAccessibility/Locales/enUS.lua
+++ b/EnhanceQoLAccessibility/Locales/enUS.lua
@@ -10,3 +10,5 @@ L["Listing activity name color"] = "Listing activity name color"
 L["Listing custom text color"] = "Listing custom text color"
 
 L["Listing background color"] = "Listing background color"
+L["Reset to default"] = "Reset to default"
+L["FontChangeHint"] = "This changes the fonts used by EnhanceQoL"

--- a/EnhanceQoLMouse/EnhanceQoLMouse.lua
+++ b/EnhanceQoLMouse/EnhanceQoLMouse.lua
@@ -248,8 +248,9 @@ local function addGeneralFrame(container)
 		groupCore:AddChild(addon.functions.createSpacerAce())
 
 		-- Direkt hinter dem DropDown:
-		local colorPicker = AceGUI:Create("ColorPicker")
-		colorPicker:SetLabel(L["Ring Color"])
+               local colorPicker = AceGUI:Create("ColorPicker")
+               colorPicker:SetLabel(L["Ring Color"])
+               if colorPicker.text and colorPicker.text.SetFont then colorPicker.text:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
 		-- colorPicker:SetHasAlpha(true) -- Falls du Transparenz erlauben willst
 		-- Alte Werte (falls gesetzt) aus dem SavedVariables laden:
 		if addon.db["mouseRingColor"] then
@@ -303,8 +304,9 @@ local function addGeneralFrame(container)
 			groupTrail:AddChild(addon.functions.createSpacerAce())
 
 			-- Direkt hinter dem DropDown:
-			local colorPicker = AceGUI:Create("ColorPicker")
-			colorPicker:SetLabel(L["Trail Color"])
+                       local colorPicker = AceGUI:Create("ColorPicker")
+                       colorPicker:SetLabel(L["Trail Color"])
+                       if colorPicker.text and colorPicker.text.SetFont then colorPicker.text:SetFont(addon.variables.defaultFont, 14, "OUTLINE") end
 			colorPicker:SetHasAlpha(true) -- Falls du Transparenz erlauben willst
 			-- Alte Werte (falls gesetzt) aus dem SavedVariables laden:
 			if addon.db["mouseTrailColor"] then

--- a/EnhanceQoLVendor/EnhanceQoLVendor.lua
+++ b/EnhanceQoLVendor/EnhanceQoLVendor.lua
@@ -153,14 +153,15 @@ local eventHandlers = {
 	end,
 	["ITEM_DATA_LOAD_RESULT"] = function(arg1, arg2)
 		if arg2 == false and addon.aceFrame:IsShown() and lastEbox then
-			StaticPopupDialogs["VendorWrongItemID"] = {
-				text = L["Item id does not exist"],
-				button1 = "OK",
-				timeout = 0,
-				whileDead = true,
-				hideOnEscape = true,
-				preferredIndex = 3, -- avoid some UI taint, see http://www.wowace.com/announcements/how-to-avoid-some-ui-taint/
-			}
+                       StaticPopupDialogs["VendorWrongItemID"] = {
+                               text = L["Item id does not exist"],
+                               button1 = "OK",
+                               timeout = 0,
+                               whileDead = true,
+                               hideOnEscape = true,
+                               preferredIndex = 3, -- avoid some UI taint, see http://www.wowace.com/announcements/how-to-avoid-some-ui-taint/
+                               OnShow = function(self) addon.functions.applyPopupFonts(self) end,
+                       }
 			StaticPopup_Show("VendorWrongItemID")
 			lastEbox:SetText("")
 		end


### PR DESCRIPTION
## Summary
- add locale default font utility and popup font helper
- ensure ChatIM widgets use configured fonts
- apply default font to color picker labels
- add reset to default font option with hint text
- update static popups to set fonts

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_6851078502e88329951d0d7b0b74543a