### PR TITLE
Support multiple mapIDs for mega dungeons

### DIFF
--- a/EnhanceQoLMythicPlus/DungeonPortal.lua
+++ b/EnhanceQoLMythicPlus/DungeonPortal.lua
@@ -63,7 +63,15 @@ local function getCurrentSeasonPortal()
 								background = backgroundTexture,
 							}
 						end
-						if data.mapID then filteredMapID[data.mapID] = cId end
+						if data.mapID then
+							if type(data.mapID) == "table" then
+								for _, mID in pairs(data.mapID) do
+									filteredMapID[mID] = cId
+								end
+							else
+								filteredMapID[data.mapID] = cId
+							end
+						end
 						break
 					end
 				end

--- a/EnhanceQoLMythicPlus/Init.lua
+++ b/EnhanceQoLMythicPlus/Init.lua
@@ -430,7 +430,15 @@ addon.MythicPlus.variables.portalCompendium = {
 			[354467] = { text = "TOP", cId = { [382] = true }, mapID = 2293 },
 			[354468] = { text = "DOS", cId = { [377] = true } },
 			[354469] = { text = "SD", cId = { [380] = true } },
-			[367416] = { text = "TAZA", cId = { [391] = true, [392] = true }, mapID = 1989 },
+			-- Tazavesh was split into two seperate instances. Both halves
+			-- share the same teleport spell but have different mapIDs.  To
+			-- support this the mapID entry can now contain a table with the
+			-- cId as key and the associated instance mapID as value.
+			[367416] = {
+				text = "TAZA",
+				cId = { [391] = true, [392] = true },
+				mapID = { [391] = 2441, [392] = 2442 },
+			},
 			[373190] = { text = "CN", isRaid = true }, -- Raids
 			[373192] = { text = "SFO", isRaid = true }, -- Raids
 			[373191] = { text = "SOD", isRaid = true }, -- Raids

--- a/EnhanceQoLMythicPlus/TalentReminder.lua
+++ b/EnhanceQoLMythicPlus/TalentReminder.lua
@@ -28,10 +28,16 @@ local function createSeasonInfo()
 		for spellID, data in pairs(section.spells) do
 			if data.mapID and data.cId then
 				for cId in pairs(data.cId) do
-					if cModeIDLookup[cId] and not addon.MythicPlus.variables.seasonMapHash[data.mapID] then
+					local mID
+					if type(data.mapID) == "table" then
+						mID = data.mapID[cId]
+					else
+						mID = data.mapID
+					end
+					if mID and cModeIDLookup[cId] and not addon.MythicPlus.variables.seasonMapHash[mID] then
 						local mapName = C_ChallengeMode.GetMapUIInfo(cId)
-						table.insert(addon.MythicPlus.variables.seasonMapInfo, { name = mapName, id = data.mapID })
-						addon.MythicPlus.variables.seasonMapHash[data.mapID] = true
+						table.insert(addon.MythicPlus.variables.seasonMapInfo, { name = mapName, id = mID })
+						addon.MythicPlus.variables.seasonMapHash[mID] = true
 					end
 				end
 			end


### PR DESCRIPTION
## Summary
- allow storing several mapIDs per teleport spell
- handle mapID tables in dungeon portal and talent reminder logic
- add map IDs for the two halves of Tazavesh

## Testing
- `luacheck EnhanceQoLMythicPlus/Init.lua EnhanceQoLMythicPlus/DungeonPortal.lua EnhanceQoLMythicPlus/TalentReminder.lua`

------
https://chatgpt.com/codex/tasks/task_e_685995b39e4083298855135e6e87474a