### PR TITLE
Add Instant Catalyst button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **TWW S3 Catalyst Currency**
 - **Dungeon Teleports for TWW S3**
 - **Updated TOC for 11.2.0**
+- **Instant Catalyst button**
 
 ### 🐛 Fixed
 - Character frame reliably shows **Catalyst charges** again

--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -2214,6 +2214,15 @@ local function addMiscFrame(container, d)
 			type = "CheckBox",
 			callback = function(self, _, value) addon.db["autoQuickLoot"] = value end,
 		},
+		{
+			parent = "",
+			var = "instantCatalystEnabled",
+			type = "CheckBox",
+			callback = function(self, _, value)
+				addon.db["instantCatalystEnabled"] = value
+				addon.functions.toggleInstantCatalystButton(value)
+			end,
+		},
 	}
 
 	addon.functions.createWrapperData(data, container, L)
@@ -2624,6 +2633,7 @@ local function initMisc()
 	addon.functions.InitDBValue("hideMinimapButton", false)
 	addon.functions.InitDBValue("hideBagsBar", false)
 	addon.functions.InitDBValue("hideMicroMenu", false)
+	addon.functions.InitDBValue("instantCatalystEnabled", false)
 	--@debug@
 	addon.functions.InitDBValue("automaticallyOpenContainer", false)
 	--@end-debug@
@@ -3423,6 +3433,40 @@ function addon.functions.createCatalystFrame()
 	end
 end
 
+function addon.functions.createInstantCatalystButton()
+	if not ItemInteractionFrame or EnhanceQoLInstantCatalyst then return end
+
+	local parent = ItemInteractionFrame.ButtonFrame or ItemInteractionFrame
+	local anchor = parent and (parent.AcceptButton or parent.ActionButton)
+
+	local button = CreateFrame("Button", "EnhanceQoLInstantCatalyst", parent, "UIPanelButtonTemplate")
+	button:SetSize(120, 22)
+	button:SetText("Instant")
+	button:SetEnabled(false)
+
+	if anchor then
+		button:SetPoint("LEFT", anchor, "RIGHT", 4, 0)
+	else
+		button:SetPoint("BOTTOM", parent, "BOTTOM", 0, 4)
+	end
+
+	button:SetScript("OnClick", function() C_ItemInteraction.PerformItemInteraction() end)
+
+	ItemInteractionFrame:HookScript("OnShow", function() button:SetEnabled(false) end)
+end
+
+function addon.functions.toggleInstantCatalystButton(value)
+	if not IsAddOnLoaded("Blizzard_ItemInteractionUI") then return end
+	if not ItemInteractionFrame then return end
+
+	if value then
+		if not EnhanceQoLInstantCatalyst then addon.functions.createInstantCatalystButton() end
+		if EnhanceQoLInstantCatalyst then EnhanceQoLInstantCatalyst:Show() end
+	elseif EnhanceQoLInstantCatalyst then
+		EnhanceQoLInstantCatalyst:Hide()
+	end
+end
+
 local function initCharacter()
 	addon.functions.InitDBValue("showIlvlOnBankFrame", false)
 	addon.functions.InitDBValue("showIlvlOnMerchantframe", false)
@@ -4086,11 +4130,7 @@ local eventHandlers = {
 
 			checkBagIgnoreJunk()
 		end
-		if arg1 == "Blizzard_ItemInteractionUI" then
-			if addon.db["instantCatalystEnabled"] then
-
-			end
-		end
+		if arg1 == "Blizzard_ItemInteractionUI" then addon.functions.toggleInstantCatalystButton(addon.db["instantCatalystEnabled"]) end
 	end,
 	--@debug@
 	["BAG_UPDATE_DELAYED"] = function(arg1)
@@ -4192,9 +4232,9 @@ local eventHandlers = {
 		if not ItemInteractionFrame:IsShown() then return end
 		if not EnhanceQoLInstantCatalyst then return end
 		if arg1 == nil then
-			-- disable my own button
+			EnhanceQoLInstantCatalyst:SetEnabled(false)
 		else
-			-- enable my own button
+			EnhanceQoLInstantCatalyst:SetEnabled(true)
 		end
 	end,
 	["INVENTORY_SEARCH_UPDATE"] = function()

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -93,6 +93,7 @@ L["ignoreWarbandCompleted"] = "Don't automatically handle %s %s"
 
 L["autoQuickLoot"] = "Quick loot items"
 L["openCharframeOnUpgrade"] = "Open the character frame when upgrading items at the vendor"
+L["instantCatalystEnabled"] = "Instant Catalyst button"
 
 L["headerClassInfo"] = "These settings only apply to %s"
 

--- a/docs/OptionsReference.md
+++ b/docs/OptionsReference.md
@@ -95,6 +95,7 @@ Each action bar can be set to appear only on mouseover:
 - **Automatically confirm to sell tradeable loot** (Automatically confirm to sell tradeable loot within the trade window time frame).
 - **Open the character frame when upgrading items at the vendor** (Open the character frame when upgrading items at the vendor).
 - **Quick loot items** (Quick loot items).
+- **Instant Catalyst button** (Instant Catalyst button).
 
 ## Map Tools
 - **Enable /way command** (Enable /way command): provides a simple waypoint command if no other addon uses /way.


### PR DESCRIPTION
## Summary
- implement Instant Catalyst button for ItemInteractionFrame
- add option to toggle the button under Misc
- localise new option and document it
- record new feature in changelog
- enable runtime toggle for new button

## Testing
- `stylua **/*.lua`


------
https://chatgpt.com/codex/tasks/task_e_6859a4d5310883298653b833c65ef822