### PR TITLE
Fix tooltip realm nil concatenation

### DIFF
--- a/EnhanceQoLTooltip/EnhanceQoLTooltip.lua
+++ b/EnhanceQoLTooltip/EnhanceQoLTooltip.lua
@@ -35,9 +35,12 @@ local function checkCurrency(tooltip, id)
 	if not addon.db["TooltipShowCurrencyAccountWide"] then return end
 	local charList = C_CurrencyInfo.FetchCurrencyDataFromAccountCharacters(id)
 
-	local playerName, playerRealm = UnitFullName("player")
-	local playerFullName = playerName .. "-" .. playerRealm
-	local playerQty = C_CurrencyInfo.GetCurrencyInfo(id).quantity or 0
+        local playerName, playerRealm = UnitFullName("player")
+        if not playerRealm or playerRealm == "" then
+                playerRealm = GetRealmName():gsub("%s+", "")
+        end
+        local playerFullName = playerName .. "-" .. playerRealm
+        local playerQty = C_CurrencyInfo.GetCurrencyInfo(id).quantity or 0
 
 	if nil == charList or #charList == 0 then
 		-- no warband resources - just skip all to only show the player itself by blizzard


### PR DESCRIPTION
## Summary
- guard against missing `playerRealm` to avoid runtime errors

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_685b945a94b883298a8b800dae54a4f0