### PR TITLE
Fix ignore entry removal by index

### DIFF
--- a/EnhanceQoL/Submodules/Ignore/Ignore.lua
+++ b/EnhanceQoL/Submodules/Ignore/Ignore.lua
@@ -221,9 +221,16 @@ local function addEntry(name, note, expires)
 end
 
 removeEntryByIndex = function(index)
-	if origDelIgnoreByIndex then origDelIgnoreByIndex(index) end
-	table.remove(Ignore.entries, index)
-	refreshList()
+        local entry = Ignore.entries[index]
+        if entry then
+                local fullName = entry.player
+                if entry.server and entry.server ~= "" then
+                        fullName = fullName .. "-" .. entry.server
+                end
+                removeEntry(fullName)
+        end
+        table.remove(Ignore.entries, index)
+        refreshList()
 end
 
 local function removeEntry(name)


### PR DESCRIPTION
## Summary
- fix `removeEntryByIndex` to fetch from Ignore.entries and call `removeEntry`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c5d53ba388329a2ba6cc35467b3f2