### PR TITLE
Fix DelIgnore call in removeEntry

### DIFF
--- a/EnhanceQoL/Submodules/Ignore/Ignore.lua
+++ b/EnhanceQoL/Submodules/Ignore/Ignore.lua
@@ -234,18 +234,12 @@ removeEntryByIndex = function(index)
 end
 
 local function removeEntry(name)
-        if origDelIgnore then
-                local ignored
-                if C_FriendList and C_FriendList.IsIgnored then
-                        ignored = C_FriendList.IsIgnored(name)
-                elseif IsIgnored then
-                        ignored = IsIgnored(name)
-                end
-                if ignored then origDelIgnore(name) end
+        if origDelIgnore and IsIgnored and IsIgnored(name) then
+                origDelIgnore(name)
         end
         local player, server = strsplit("-", name)
-	for i, entry in ipairs(Ignore.entries) do
-		if entry.player == player and entry.server == (server or "") then
+        for i, entry in ipairs(Ignore.entries) do
+                if entry.player == player and entry.server == (server or "") then
 			table.remove(Ignore.entries, i)
 			break
 		end


### PR DESCRIPTION
## Summary
- only call the original `DelIgnore` if the entry is currently ignored

## Testing
- `luacheck EnhanceQoL/Submodules/Ignore/Ignore.lua`

------
https://chatgpt.com/codex/tasks/task_e_685c61fb0c8c8329b42caf4f2cf422ab