### PR TITLE
Fix ignore search reset

### DIFF
--- a/EnhanceQoL/Submodules/Ignore/Ignore.lua
+++ b/EnhanceQoL/Submodules/Ignore/Ignore.lua
@@ -112,14 +112,15 @@ function Ignore:CreateUI()
 	frame:SetWidth(650)
 	frame:SetHeight(400)
 	frame:SetLayout("List")
-	frame:SetCallback("OnClose", function(widget)
-		AceGUI:Release(widget)
-		if self.searchBox then
-			AceGUI:Release(self.searchBox)
-			self.searchBox = nil
-		end
-		self.window = nil
-	end)
+       frame:SetCallback("OnClose", function(widget)
+               AceGUI:Release(widget)
+               if self.searchBox then
+                       AceGUI:Release(self.searchBox)
+                       self.searchBox = nil
+               end
+               self.window = nil
+               Ignore.searchText = ""
+       end)
 
 	local spacer = AceGUI:Create("Label")
 	spacer:SetText(" ")


### PR DESCRIPTION
## Summary
- reset the ignore search text when closing the window

## Testing
- `luacheck EnhanceQoL/Submodules/Ignore/Ignore.lua`

------
https://chatgpt.com/codex/tasks/task_e_685c6ad26f48832999486c4d1aa72916