### PR TITLE
Replace AceGUI ignore table with Blizzard ScrollFrame

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19797,6 +19797,9 @@ globals = {
 	"AUCTION_HOUSE_SELLER_YOU",
 	"COPY_CHARACTER_NAME",
 	"ChatFrame_SendTell",
-	"ChatEdit_SetLastTellTarget",
-	"ChatEdit_SetLastToldTarget",
+        "ChatEdit_SetLastTellTarget",
+        "ChatEdit_SetLastToldTarget",
+        "HybridScrollFrame_GetOffset",
+        "HybridScrollFrame_Update",
+        "MAX_IGNORE",
 }


### PR DESCRIPTION
## Summary
- remove AceGUI table usage from Ignore list
- implement IgnoreRowMixin and populate rows in a HybridScrollFrame
- allow new globals for luacheck

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_685ccd8824388329a7cd66d789fb774b