### PR TITLE
Add validation for ignore expiration

### DIFF
--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -211,3 +211,4 @@ L["persistAuctionHouseFilter"] = "Remember Auction House filters for this sessio
 
 L["Excluded NPCs"] = "Excluded NPCs"
 L["hideDynamicFlightBar"] = "Hide %s Vigor bar while on the ground"
+L["InvalidExpiration"] = "Invalid expiration value"

--- a/EnhanceQoL/Submodules/Ignore/Ignore.lua
+++ b/EnhanceQoL/Submodules/Ignore/Ignore.lua
@@ -403,6 +403,7 @@ function Ignore:ShowAddFrame(name, note, expires)
 	check:SetCallback("OnValueChanged", function(_, _, value)
 		numBox:SetDisabled(not value)
 		numBox.frame:SetShown(value)
+		if not value then numBox:SetText("") end
 	end)
 
 	if expires and expires ~= NEVER then
@@ -428,7 +429,13 @@ function Ignore:ShowAddFrame(name, note, expires)
 	addBtn:SetCallback("OnClick", function()
 		local n = editBox:GetText()
 		local exp = ""
-		if check:GetValue() then exp = tonumber(numBox:GetText()) end
+		if check:GetValue() then
+			exp = tonumber(numBox:GetText())
+			if not exp then
+				print(addon.L["InvalidExpiration"])
+				return
+			end
+		end
 		addEntry(name, n, exp)
 		frame:Hide()
 	end)


### PR DESCRIPTION
## Summary
- handle invalid expiration in Ignore UI
- add 'InvalidExpiration' localization

## Testing
- `luacheck EnhanceQoL/Submodules/Ignore/Ignore.lua`
- `stylua EnhanceQoL/Submodules/Ignore/Ignore.lua`

------
https://chatgpt.com/codex/tasks/task_e_685da7d344d883299cd010060968d5ca