### PR TITLE
Fix ignore checks for ChatIM whispers

### DIFF
--- a/EnhanceQoL/Submodules/ChatIM/Core.lua
+++ b/EnhanceQoL/Submodules/ChatIM/Core.lua
@@ -6,6 +6,7 @@ else
 	error(parentAddonName .. " is not loaded")
 end
 local LSM = LibStub("LibSharedMedia-3.0")
+local Ignore = addon.Ignore
 
 local ChatIM = addon.ChatIM or {}
 addon.ChatIM = ChatIM
@@ -90,22 +91,36 @@ frame:SetScript("OnEvent", function(_, event, ...)
 			ChatIM.pendingShow = false
 			ChatIM.soundQueue = {}
 		end
-	elseif event == "CHAT_MSG_WHISPER" then
-		local msg, sender = ...
-		ChatIM:AddMessage(sender, msg)
-		if addon.db and addon.db["chatIMHideInCombat"] and ChatIM.inCombat then
-			table.insert(ChatIM.soundQueue, sender)
-			ChatIM.pendingShow = true
+       elseif event == "CHAT_MSG_WHISPER" then
+               local msg, sender = ...
+               if
+                       (Ignore and Ignore.IsPlayerIgnored and Ignore:IsPlayerIgnored(sender))
+                       or (C_FriendList.IsIgnored and C_FriendList.IsIgnored(sender))
+                       or (IsIgnored and IsIgnored(sender))
+               then
+                       return
+               end
+               ChatIM:AddMessage(sender, msg)
+               if addon.db and addon.db["chatIMHideInCombat"] and ChatIM.inCombat then
+                       table.insert(ChatIM.soundQueue, sender)
+                       ChatIM.pendingShow = true
 		else
 			playIncomingSound(sender)
 			ChatIM:Flash()
 		end
-	elseif event == "CHAT_MSG_BN_WHISPER" then
-		local msg, sender, _, _, _, _, _, _, _, _, _, _, bnetID = ...
-		ChatIM:AddMessage(sender, msg, nil, true, bnetID)
-		if addon.db and addon.db["chatIMHideInCombat"] and ChatIM.inCombat then
-			table.insert(ChatIM.soundQueue, sender)
-			ChatIM.pendingShow = true
+       elseif event == "CHAT_MSG_BN_WHISPER" then
+               local msg, sender, _, _, _, _, _, _, _, _, _, _, bnetID = ...
+               if
+                       (Ignore and Ignore.IsPlayerIgnored and Ignore:IsPlayerIgnored(sender))
+                       or (C_FriendList.IsIgnored and C_FriendList.IsIgnored(sender))
+                       or (IsIgnored and IsIgnored(sender))
+               then
+                       return
+               end
+               ChatIM:AddMessage(sender, msg, nil, true, bnetID)
+               if addon.db and addon.db["chatIMHideInCombat"] and ChatIM.inCombat then
+                       table.insert(ChatIM.soundQueue, sender)
+                       ChatIM.pendingShow = true
 		else
 			playIncomingSound(sender)
 			ChatIM:Flash()

--- a/EnhanceQoL/Submodules/Ignore/Ignore.lua
+++ b/EnhanceQoL/Submodules/Ignore/Ignore.lua
@@ -612,9 +612,31 @@ Ignore.groupCheckFrame:SetScript("OnEvent", function()
 		StaticPopup_Show("EQOL_IGNORE_GROUP")
 	end
 
-	Ignore.groupCheckFrame.lastPartySize = size
-	Ignore.groupCheckFrame.lastIgnored = count
+Ignore.groupCheckFrame.lastPartySize = size
+Ignore.groupCheckFrame.lastIgnored = count
 end)
+
+-- chat message filter to block messages from ignored players
+local function ignoreChatFilter(_, _, _, sender)
+    if Ignore:IsPlayerIgnored(sender) then return true end
+    return false
+end
+
+for _, e in ipairs({
+    "CHAT_MSG_WHISPER",
+    "CHAT_MSG_BN_WHISPER",
+    "CHAT_MSG_GUILD",
+    "CHAT_MSG_OFFICER",
+    "CHAT_MSG_PARTY",
+    "CHAT_MSG_PARTY_LEADER",
+    "CHAT_MSG_RAID",
+    "CHAT_MSG_RAID_LEADER",
+    "CHAT_MSG_RAID_WARNING",
+    "CHAT_MSG_INSTANCE_CHAT",
+    "CHAT_MSG_INSTANCE_CHAT_LEADER",
+}) do
+    ChatFrame_AddMessageEventFilter(e, ignoreChatFilter)
+end
 
 Ignore.interactionBlocker = Ignore.interactionBlocker or CreateFrame("Frame")
 for _, evt in ipairs({ "PARTY_INVITE_REQUEST", "DUEL_REQUESTED", "PET_BATTLE_PVP_DUEL_REQUESTED", "TRADE_SHOW", "GUILD_INVITE_REQUEST" }) do


### PR DESCRIPTION
## Summary
- check EnhanceQoL ignore list when whispers arrive
- add chat event filter to Ignore module so blocked names don't appear in chat

## Testing
- `bash scripts/build.sh` *(fails: `sed: can't read s/@project-version@/3.22.1-91-g778d36a/: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_685dbf7676708329ba026a20842fce5e