### PR TITLE
Normalize ignore names

### DIFF
--- a/EnhanceQoL/Submodules/ChatIM/Core.lua
+++ b/EnhanceQoL/Submodules/ChatIM/Core.lua
@@ -92,7 +92,7 @@ frame:SetScript("OnEvent", function(_, event, ...)
 		end
 	elseif event == "CHAT_MSG_WHISPER" then
 		local msg, sender = ...
-		if addon.Ignore and addon.Ignore.IsPlayerIgnored and addon.Ignore:IsPlayerIgnored(sender) then return end
+		if addon.Ignore and addon.Ignore.CheckIgnore and addon.Ignore:CheckIgnore(sender) then return end
 		ChatIM:AddMessage(sender, msg)
 		if addon.db and addon.db["chatIMHideInCombat"] and ChatIM.inCombat then
 			table.insert(ChatIM.soundQueue, sender)


### PR DESCRIPTION
## Summary
- add `Ignore:NormalizeName` and `Ignore:CheckIgnore`
- normalize keys when populating ignore entries
- use `CheckIgnore` in chat filter, interaction blocking, and group roster checks
- update ChatIM whisper handler

## Testing
- `luacheck EnhanceQoL/Submodules/Ignore/Ignore.lua EnhanceQoL/Submodules/ChatIM/Core.lua`


------
https://chatgpt.com/codex/tasks/task_e_685e1e2d3d788329983131931851d7ac