### PR TITLE
Add enable toggle for Ignore module

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -2405,9 +2405,14 @@ local function addSocialFrame(container)
 	for _, checkboxData in ipairs(data) do
 		local desc
 		if checkboxData.desc then desc = checkboxData.desc end
-		local cb = addon.functions.createCheckboxAce(checkboxData.text, addon.db[checkboxData.var], function(self, _, value) addon.db[checkboxData.var] = value end, desc)
-		groupCore:AddChild(cb)
-	end
+               local cb = addon.functions.createCheckboxAce(checkboxData.text, addon.db[checkboxData.var], function(self, _, value)
+                       addon.db[checkboxData.var] = value
+                       if addon.Ignore and addon.Ignore.SetEnabled then addon.Ignore:SetEnabled(value) end
+                       addon.variables.requireReload = true
+                       addon.functions.checkReloadFrame()
+               end, desc)
+               groupCore:AddChild(cb)
+       end
 
 	local wrapper = addon.functions.createWrapperData(data, container, L)
 	local labelHeadline = addon.functions.createLabelAce("|cffffd700" .. L["IgnoreDesc"], nil, nil, 14)

--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -2405,14 +2405,14 @@ local function addSocialFrame(container)
 	for _, checkboxData in ipairs(data) do
 		local desc
 		if checkboxData.desc then desc = checkboxData.desc end
-               local cb = addon.functions.createCheckboxAce(checkboxData.text, addon.db[checkboxData.var], function(self, _, value)
-                       addon.db[checkboxData.var] = value
-                       if addon.Ignore and addon.Ignore.SetEnabled then addon.Ignore:SetEnabled(value) end
-                       addon.variables.requireReload = true
-                       addon.functions.checkReloadFrame()
-               end, desc)
-               groupCore:AddChild(cb)
-       end
+		local cb = addon.functions.createCheckboxAce(checkboxData.text, addon.db[checkboxData.var], function(self, _, value)
+			addon.db[checkboxData.var] = value
+			if addon.Ignore and addon.Ignore.SetEnabled then addon.Ignore:SetEnabled(value) end
+			addon.variables.requireReload = true
+			addon.functions.checkReloadFrame()
+		end, desc)
+		groupCore:AddChild(cb)
+	end
 
 	local wrapper = addon.functions.createWrapperData(data, container, L)
 	local labelHeadline = addon.functions.createLabelAce("|cffffd700" .. L["IgnoreDesc"], nil, nil, 14)


### PR DESCRIPTION
## Summary
- add `Ignore.registeredFilters` and track hooks for chat filters and API overrides
- register/restore events and hooks based on Ignore's enabled state
- show reload prompt when toggling Ignore option
- call `Ignore:SetEnabled` after the module loads

## Testing
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_685e2a99b4e48329a1c8fbcae1cfc7da