### PR TITLE
Add popup to import ignore list

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -2408,8 +2408,10 @@ local function addSocialFrame(container)
 		local cb = addon.functions.createCheckboxAce(checkboxData.text, addon.db[checkboxData.var], function(self, _, value)
 			addon.db[checkboxData.var] = value
 			if addon.Ignore and addon.Ignore.SetEnabled then addon.Ignore:SetEnabled(value) end
-			addon.variables.requireReload = true
-			addon.functions.checkReloadFrame()
+			if not value then
+				addon.variables.requireReload = true
+				addon.functions.checkReloadFrame()
+			end
 		end, desc)
 		groupCore:AddChild(cb)
 	end

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -228,3 +228,6 @@ L["IgnoreGroupPopupText"] = "The following ignored players are in your group:\n%
 L["Social"] = "Social"
 L["EnableAdvancedIgnore"] = "Enable advanced Ignore list"
 L["IgnoreDesc"] = "Blocks duel, pet battle, trade, invite and whisper requests from ignored players. Automatically adds same-realm names to Blizzard’s ignore list when space permits."
+L["ImportGILDialog"] = "GlobalIgnoreList data found. Import entries and disable that addon? Both addons cannot be active together."
+L["ImportGILCancelDialog"] = "Disable the advanced ignore option or GlobalIgnoreList and reload your interface."
+L["ImportGILAccept"] = "Import & Reload"

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -231,3 +231,4 @@ L["IgnoreDesc"] = "Blocks duel, pet battle, trade, invite and whisper requests f
 L["ImportGILDialog"] = "GlobalIgnoreList data found. Import entries and disable that addon? Both addons cannot be active together."
 L["ImportGILCancelDialog"] = "Disable the advanced ignore option or GlobalIgnoreList and reload your interface."
 L["ImportGILAccept"] = "Import & Reload"
+L["GILActivePopup"] = "Advanced ignore disabled because GlobalIgnoreList is active. Disable that addon and re-enable the option."

--- a/EnhanceQoL/Submodules/Ignore/Ignore.lua
+++ b/EnhanceQoL/Submodules/Ignore/Ignore.lua
@@ -603,6 +603,7 @@ local function showImportPopup()
 	if not C_AddOns.IsAddOnLoaded("GlobalIgnoreList") then return end
 	local gDB = GlobalIgnoreDB
 	if not (gDB and gDB.ignoreList and #gDB.ignoreList > 0) then return end
+	if StaticPopup_Visible("EQOL_IMPORT_GIL") then return end
 
 	StaticPopupDialogs["EQOL_IMPORT_GIL"] = {
 		text = L["ImportGILDialog"],
@@ -776,11 +777,7 @@ function Ignore:SetEnabled(val)
 		if C_AddOns.IsAddOnLoaded("GlobalIgnoreList") then
 			Ignore.enabled = false
 			Ignore.pendingImport = true
-			if IsLoggedIn() then
-				showImportPopup()
-			else
-				LOGIN_FRAME:RegisterEvent("PLAYER_LOGIN")
-			end
+			showImportPopup()
 			updateRegistration()
 			return
 		end

--- a/EnhanceQoL/Submodules/Ignore/Ignore.lua
+++ b/EnhanceQoL/Submodules/Ignore/Ignore.lua
@@ -727,6 +727,7 @@ local function unhookIgnoreApi()
 end
 
 local function updateRegistration()
+	LOGIN_FRAME:UnregisterAllEvents()
 	if Ignore.enabled then
 		hookIgnoreApi()
 		LOGIN_FRAME:RegisterEvent("PLAYER_LOGIN")
@@ -743,7 +744,6 @@ local function updateRegistration()
 		_G["SLASH_" .. SLASH_NAME .. "1"] = SLASH_CMD
 		SlashCmdList[SLASH_NAME] = function() Ignore:Toggle() end
 	else
-		LOGIN_FRAME:UnregisterAllEvents()
 		for _, e in ipairs(CHAT_EVENTS) do
 			if Ignore.registeredFilters[e] then
 				ChatFrame_RemoveMessageEventFilter(e, ignoreChatFilter)
@@ -758,11 +758,24 @@ local function updateRegistration()
 		SlashCmdList[SLASH_NAME] = nil
 		_G["SLASH_" .. SLASH_NAME .. "1"] = nil
 		unhookIgnoreApi()
+		if addon.db.enableIgnore and C_AddOns.IsAddOnLoaded("GlobalIgnoreList") then LOGIN_FRAME:RegisterEvent("PLAYER_LOGIN") end
 	end
 end
 
 function Ignore:SetEnabled(val)
 	Ignore.enabled = val and true or false
+	if Ignore.enabled and C_AddOns.IsAddOnLoaded("GlobalIgnoreList") then
+		Ignore.enabled = false
+		StaticPopupDialogs["EQOL_GIL_ACTIVE"] = {
+			text = L["GILActivePopup"],
+			button1 = OKAY,
+			timeout = 0,
+			whileDead = true,
+			hideOnEscape = true,
+			preferredIndex = 3,
+		}
+		StaticPopup_Show("EQOL_GIL_ACTIVE")
+	end
 	updateRegistration()
 end
 


### PR DESCRIPTION
## Summary
- replace automatic GlobalIgnoreList import with a popup prompt
- disable GlobalIgnoreList after importing
- add warning popups when user cancels the import
- add strings to enUS locale

## Testing
- `stylua EnhanceQoL/Submodules/Ignore/Ignore.lua`
- `stylua EnhanceQoL/Locales/enUS.lua`
- `luacheck EnhanceQoL/Submodules/Ignore/Ignore.lua`
- `luacheck EnhanceQoL/Locales/enUS.lua`


------
https://chatgpt.com/codex/tasks/task_e_685e369047488329b828af7a08ffea9b