### PR TITLE
Set ignore frame's strata so it shows above standard UI

### DIFF
--- a/EnhanceQoL/Submodules/Ignore/Ignore.lua
+++ b/EnhanceQoL/Submodules/Ignore/Ignore.lua
@@ -279,8 +279,9 @@ end
 
 -- Frame created from XML
 function EQOLIgnoreFrame_OnLoad(frame)
-	Ignore.frame = frame
-	local fn = frame:GetName()
+        Ignore.frame = frame
+        frame:SetFrameStrata("DIALOG")
+        local fn = frame:GetName()
 	Ignore.counter = _G[fn .. "Counter"]
 	Ignore.searchBox = _G[fn .. "SearchBox"]
 	Ignore.header = _G[fn .. "Header"]


### PR DESCRIPTION
## Summary
- ensure the ignore list window uses dialog strata so it appears over other frames

## Testing
- `luacheck EnhanceQoL/Submodules/Ignore/Ignore.lua`
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_685e43b44cfc8329a4d15208e4245d54