### PR TITLE
Add ignore expiration checks and chat feedback

### DIFF
--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -236,3 +236,5 @@ L["ImportGILCancelDialog"] = "Disable the advanced ignore option or GlobalIgnore
 L["ImportGILAccept"] = "Import & Reload"
 L["GILActivePopup"] = "Advanced ignore disabled because GlobalIgnoreList is active. Disable that addon and re-enable the option."
 L["IgnoredApplicant"] = "Player is on your Ignore list"
+L["IgnoreAdded"] = "%s has been ignored"
+L["IgnoreRemoved"] = "%s is no longer ignored"


### PR DESCRIPTION
## Summary
- add translation strings for ignore chat messages
- prevent ignoring your own character
- print a message when players are ignored or removed
- prune expired or self references when refreshing list

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_685e780b293c8329bf6d0643c33f5dd3