### PR TITLE
Implement resource frame toggle

### DIFF
--- a/EnhanceQoLAura/Init.lua
+++ b/EnhanceQoLAura/Init.lua
@@ -19,6 +19,7 @@ addon.functions.InitDBValue("personalResourceBarHealthWidth", 100)
 addon.functions.InitDBValue("personalResourceBarHealthHeight", 25)
 addon.functions.InitDBValue("personalResourceBarManaWidth", 100)
 addon.functions.InitDBValue("personalResourceBarManaHeight", 25)
+addon.functions.InitDBValue("enableResourceFrame", false)
 addon.functions.InitDBValue("buffTrackerCategories", {
 	[1] = {
 		name = "Example",


### PR DESCRIPTION
## Summary
- add database entry for enabling the resource frame
- register resource events only when the frame is enabled
- expose a function to update event registration
- hook the update to the 'Enable Resource frame' checkbox

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_68640571e1448329a1a5d51d9a5ca0ea