### PR TITLE
Add per-spec resource frame toggles

### DIFF
--- a/EnhanceQoLAura/Init.lua
+++ b/EnhanceQoLAura/Init.lua
@@ -20,6 +20,7 @@ addon.functions.InitDBValue("personalResourceBarHealthHeight", 25)
 addon.functions.InitDBValue("personalResourceBarManaWidth", 100)
 addon.functions.InitDBValue("personalResourceBarManaHeight", 25)
 addon.functions.InitDBValue("enableResourceFrame", false)
+addon.functions.InitDBValue("resourceSpecEnabled", {})
 addon.functions.InitDBValue("buffTrackerCategories", {
 	[1] = {
 		name = "Example",


### PR DESCRIPTION
## Summary
- add `resourceSpecEnabled` option
- allow enabling resource bars per specialization
- show spec tabs with power toggles in resource frame settings

## Testing
- `luacheck EnhanceQoLAura/Init.lua EnhanceQoLAura/Ressources.lua`

------
https://chatgpt.com/codex/tasks/task_e_6864095cfae4832996ea2f24ec00c4f0