### PR TITLE
Add resource frame customization

### DIFF
--- a/EnhanceQoLAura/Init.lua
+++ b/EnhanceQoLAura/Init.lua
@@ -21,6 +21,42 @@ addon.functions.InitDBValue("personalResourceBarManaWidth", 100)
 addon.functions.InitDBValue("personalResourceBarManaHeight", 25)
 addon.functions.InitDBValue("enableResourceFrame", false)
 addon.functions.InitDBValue("resourceSpecEnabled", {})
+addon.functions.InitDBValue("resourceBarSettings", {})
+
+local defaultBarTypes = {
+    "HEALTH",
+    "RAGE",
+    "ESSENCE",
+    "FOCUS",
+    "ENERGY",
+    "FURY",
+    "COMBO_POINTS",
+    "RUNIC_POWER",
+    "SOUL_SHARDS",
+    "LUNAR_POWER",
+    "HOLY_POWER",
+    "MAELSTROM",
+    "CHI",
+    "INSANITY",
+    "ARCANE_CHARGES",
+    "MANA",
+}
+
+for _, barType in ipairs(defaultBarTypes) do
+    addon.db.resourceBarSettings[barType] = addon.db.resourceBarSettings[barType] or {}
+    local opts = addon.db.resourceBarSettings[barType]
+    if opts.width == nil then opts.width = 100 end
+    if opts.height == nil then opts.height = 25 end
+    if opts.text == nil then opts.text = true end
+    if opts.fullColor == nil then
+        if barType == "HEALTH" then
+            opts.fullColor = { r = 0, g = 1, b = 0 }
+        else
+            local c = PowerBarColor[barType] or { r = 1, g = 1, b = 1 }
+            opts.fullColor = { r = c.r, g = c.g, b = c.b }
+        end
+    end
+end
 addon.functions.InitDBValue("buffTrackerCategories", {
 	[1] = {
 		name = "Example",


### PR DESCRIPTION
## Summary
- add table storing default resource bar sizes, text toggle and max color
- update health/power bar creation and updates to use settings
- extend options UI to modify width, height, text and max color for each bar

## Testing
- `luacheck EnhanceQoLAura/Init.lua EnhanceQoLAura/Ressources.lua`

------
https://chatgpt.com/codex/tasks/task_e_68640b4d03c08329a7d791326dad09dd