### PR TITLE
Fix RegisterForClicks usage

### DIFF
--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -211,11 +211,7 @@ local function createBuffFrame(icon, parent, size, castOnClick, spellID)
 		frame:SetAttribute("type", "spell")
 		frame:SetAttribute("spell", spellID)
 		frame:EnableMouse(true)
-		if InCombatLockdown() then
-			frame:RegisterForClicks(nil)
-		else
-			frame:RegisterForClicks("AnyUp", "AnyDown")
-		end
+		if not InCombatLockdown() then frame:RegisterForClicks("AnyUp", "AnyDown") end
 		frame:SetScript("PostClick", function() C_Timer.After(0.1, addon.Aura.scanBuffs) end)
 	else
 		frame:EnableMouse(false)
@@ -321,11 +317,7 @@ local function updateBuff(catId, id)
 			frame.cd:Clear()
 			if shouldSecure then
 				frame:EnableMouse(true)
-				if InCombatLockdown() then
-					frame:RegisterForClicks(nil)
-				else
-					frame:RegisterForClicks("AnyUp", "AnyDown")
-				end
+				if not InCombatLockdown() then frame:RegisterForClicks("AnyUp", "AnyDown") end
 			else
 				frame:EnableMouse(false)
 			end


### PR DESCRIPTION
## Summary
- fix invalid `RegisterForClicks(nil)` usage for secure buttons
- don't attempt `RegisterForClicks` while in combat

## Testing
- `luacheck EnhanceQoLAura/BuffTracker.lua`
- `stylua --check EnhanceQoLAura/BuffTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_6865528965c48329b32ecf6d157ce1d4