### PR TITLE
Add crafting material expansion filter

### DIFF
--- a/EnhanceQoLVendor/EnhanceQoLVendor.lua
+++ b/EnhanceQoLVendor/EnhanceQoLVendor.lua
@@ -63,6 +63,9 @@ local function checkItem()
 							-- do nothing
 							elseif addon.db["vendorIncludeSellList"][containerInfo.itemID] then -- ignore everything and include in sell
 								if sellPrice > 0 then table.insert(itemsToSell, { bag = bag, slot = slot }) end
+							elseif classID == 7 and addon.Vendor.variables.itemQualityFilter[containerInfo.quality] then
+								local expTable = addon.db["vendor" .. addon.Vendor.variables.tabNames[containerInfo.quality] .. "CraftingExpansions"]
+								if expTable and expTable[expansionID] then table.insert(itemsToSell, { bag = bag, slot = slot }) end
 							elseif addon.Vendor.variables.itemQualityFilter[containerInfo.quality] then
 								local effectiveILvl = C_Item.GetDetailedItemLevelInfo(link) -- item level of the item with all upgrades calculated
 								-- local effectiveILvl = itemLevel -- item level of the item with all upgrades calculated
@@ -293,6 +296,23 @@ local function addVendorFrame(container, type)
 			updateLegend(value, value2)
 		end)
 		groupCore:AddChild(vendorIlvl)
+
+		local expList = {}
+		for i = 0, LE_EXPANSION_LEVEL_CURRENT do
+			expList[i] = _G["EXPANSION_NAME" .. i]
+		end
+		local list, order = addon.functions.prepareListForDropdown(expList, true)
+		local dropCrafting = addon.functions.createDropdownAce(
+			L["vendorCraftingExpansions"],
+			list,
+			order,
+			function(self, event, key, checked) addon.db["vendor" .. value .. "CraftingExpansions"][key] = checked or nil end
+		)
+		dropCrafting:SetMultiselect(true)
+		for id, val in pairs(addon.db["vendor" .. value .. "CraftingExpansions"]) do
+			if val then dropCrafting:SetItemValue(tonumber(id), true) end
+		end
+		groupCore:AddChild(dropCrafting)
 
 		if addon.db["vendor" .. value .. "IgnoreWarbound"] then table.insert(text, L["vendorIgnoreWarbound"]) end
 		if addon.db["vendor" .. value .. "IgnoreBoE"] then table.insert(text, L["vendorIgnoreBoE"]) end

--- a/EnhanceQoLVendor/Init.lua
+++ b/EnhanceQoLVendor/Init.lua
@@ -44,6 +44,7 @@ for key, value in pairs(addon.Vendor.variables.tabNames) do
 	addon.functions.InitDBValue("vendor" .. value .. "IgnoreWarbound", true)
 	addon.functions.InitDBValue("vendor" .. value .. "IgnoreBoE", true)
 	addon.functions.InitDBValue("vendor" .. value .. "AbsolutIlvl", false)
+	addon.functions.InitDBValue("vendor" .. value .. "CraftingExpansions", {})
 
 	if key ~= 1 then
 		addon.functions.InitDBValue("vendor" .. value .. "IgnoreUpgradable", false)

--- a/EnhanceQoLVendor/Locales/enUS.lua
+++ b/EnhanceQoLVendor/Locales/enUS.lua
@@ -37,3 +37,4 @@ L["labelItemQualityline"] = "This enabled you to automatically sell %s items bas
 L["vendorEnable"] = "Enable automatic selling for %s items"
 L["labelExplainedline"] = "This means it automatically sells %s items with an ilvl of %s and lower %s"
 L["andWord"] = "and"
+L["vendorCraftingExpansions"] = "Crafting material expansions"


### PR DESCRIPTION
## Summary
- add new localization for crafting expansion dropdown
- store selected expansions per rarity
- allow choosing expansions via multiselect dropdown
- vendor crafting materials from chosen expansions

## Testing
- `luacheck EnhanceQoLVendor/EnhanceQoLVendor.lua EnhanceQoLVendor/Init.lua EnhanceQoLVendor/Locales/enUS.lua`

------
https://chatgpt.com/codex/tasks/task_e_68655d3c0ebc8329940690d1e4904665