### PR TITLE
Improve loot toast filtering logic

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -2327,6 +2327,10 @@ local function addMiscFrame(container, d)
 		group:AddChild(addon.functions.createCheckboxAce(L["lootToastIncludePets"], addon.db.lootToastIncludePets, function(self, _, val) addon.db.lootToastIncludePets = val end))
 
 		group:AddChild(addon.functions.createCheckboxAce(L["lootToastIncludeLegendaries"], addon.db.lootToastIncludeLegendaries, function(self, _, val) addon.db.lootToastIncludeLegendaries = val end))
+
+		local label = addon.functions.createLabelAce("|cffffd700" .. L["lootToastExplanation"] .. "|r", nil, nil, 14)
+		label:SetFullWidth(true)
+		group:AddChild(label)
 	end
 	scroll:DoLayout()
 end

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -103,6 +103,8 @@ L["lootToastRarity"] = "Rarities"
 L["lootToastIncludeMounts"] = "Show for mounts"
 L["lootToastIncludePets"] = "Show for pets"
 L["lootToastIncludeLegendaries"] = "Show for legendaries"
+L["lootToastExplanation"] =
+	"Only loot toasts that match at least one filter will be shown. If rarity filtering is enabled the selected rarities also apply to mounts and pets. Item level is ignored for mounts and pets."
 
 L["headerClassInfo"] = "These settings only apply to %s"
 

--- a/EnhanceQoL/Submodules/LootToast.lua
+++ b/EnhanceQoL/Submodules/LootToast.lua
@@ -2,9 +2,9 @@
 local parentAddonName = "EnhanceQoL"
 local addonName, addon = ...
 if _G[parentAddonName] then
-    addon = _G[parentAddonName]
+	addon = _G[parentAddonName]
 else
-    error(parentAddonName .. " is not loaded")
+	error(parentAddonName .. " is not loaded")
 end
 
 local LootToast = addon.LootToast or {}
@@ -12,56 +12,61 @@ addon.LootToast = LootToast
 LootToast.enabled = false
 LootToast.frame = LootToast.frame or CreateFrame("Frame")
 
+local function passesRarity(item)
+	if not addon.db.lootToastCheckRarity then return true end
+	local quality = select(3, C_Item.GetItemInfo(item:GetItemLink()))
+	return addon.db.lootToastRarities and addon.db.lootToastRarities[quality]
+end
+
+local function isMount(item)
+	local classID, subClassID = select(12, C_Item.GetItemInfo(item:GetItemLink()))
+	return classID == 15 and subClassID == 5
+end
+
+local function isPet(item)
+	local classID = select(12, C_Item.GetItemInfo(item:GetItemLink()))
+	return classID == 17
+end
+
 local function shouldShowToast(item)
-    local show = false
-    if addon.db.lootToastCheckIlvl and item:GetCurrentItemLevel() >= addon.db.lootToastItemLevel then
-        show = true
-    end
-    if not show and addon.db.lootToastCheckRarity then
-        local quality = select(3, C_Item.GetItemInfo(item:GetItemLink()))
-        if addon.db.lootToastRarities and addon.db.lootToastRarities[quality] then show = true end
-    end
-    if not show and addon.db.lootToastIncludeMounts then
-        local classID, subClassID = select(12, C_Item.GetItemInfo(item:GetItemLink()))
-        if classID == 15 and subClassID == 5 then show = true end
-    end
-    if not show and addon.db.lootToastIncludePets then
-        local classID = select(12, C_Item.GetItemInfo(item:GetItemLink()))
-        if classID == 17 then show = true end
-    end
-    if not show and addon.db.lootToastIncludeLegendaries then
-        local quality = select(3, C_Item.GetItemInfo(item:GetItemLink()))
-        if quality == Enum.ItemQuality.Legendary then show = true end
-    end
-    return show
+	if addon.db.lootToastIncludeLegendaries then
+		local quality = select(3, C_Item.GetItemInfo(item:GetItemLink()))
+		if quality == Enum.ItemQuality.Legendary then return true end
+	end
+
+	if addon.db.lootToastIncludeMounts and isMount(item) then return passesRarity(item) end
+	if addon.db.lootToastIncludePets and isPet(item) then return passesRarity(item) end
+
+	if addon.db.lootToastCheckIlvl and item:GetCurrentItemLevel() >= addon.db.lootToastItemLevel then return true end
+
+	if addon.db.lootToastCheckRarity and passesRarity(item) then return true end
+
+	return false
 end
 
 function LootToast:OnEvent(_, _, ...)
-    local typeIdentifier, itemLink, quantity, specID, _, _, _, lessAwesome, isUpgraded, isCorrupted = ...
-    if typeIdentifier ~= "item" then return end
-    local item = Item:CreateFromItemLink(itemLink)
-    if not item or item:IsItemEmpty() then return end
-    item:ContinueOnItemLoad(function()
-        if shouldShowToast(item) then
-            LootAlertSystem:AddAlert(itemLink, quantity, nil, nil, specID, nil, nil, nil, lessAwesome, isUpgraded, isCorrupted)
-        end
-    end)
+	local typeIdentifier, itemLink, quantity, specID, _, _, _, lessAwesome, isUpgraded, isCorrupted = ...
+	if typeIdentifier ~= "item" then return end
+	local item = Item:CreateFromItemLink(itemLink)
+	if not item or item:IsItemEmpty() then return end
+	item:ContinueOnItemLoad(function()
+		if shouldShowToast(item) then LootAlertSystem:AddAlert(itemLink, quantity, nil, nil, specID, nil, nil, nil, lessAwesome, isUpgraded, isCorrupted) end
+	end)
 end
 
 function LootToast:Enable()
-    if self.enabled then return end
-    self.enabled = true
-    self.frame:RegisterEvent("SHOW_LOOT_TOAST")
-    self.frame:SetScript("OnEvent", function(...) self:OnEvent(...) end)
-    -- disable default toast
-    if AlertFrame:IsEventRegistered("SHOW_LOOT_TOAST") then AlertFrame:UnregisterEvent("SHOW_LOOT_TOAST") end
+	if self.enabled then return end
+	self.enabled = true
+	self.frame:RegisterEvent("SHOW_LOOT_TOAST")
+	self.frame:SetScript("OnEvent", function(...) self:OnEvent(...) end)
+	-- disable default toast
+	if AlertFrame:IsEventRegistered("SHOW_LOOT_TOAST") then AlertFrame:UnregisterEvent("SHOW_LOOT_TOAST") end
 end
 
 function LootToast:Disable()
-    if not self.enabled then return end
-    self.enabled = false
-    self.frame:UnregisterEvent("SHOW_LOOT_TOAST")
-    self.frame:SetScript("OnEvent", nil)
-    AlertFrame:RegisterEvent("SHOW_LOOT_TOAST")
+	if not self.enabled then return end
+	self.enabled = false
+	self.frame:UnregisterEvent("SHOW_LOOT_TOAST")
+	self.frame:SetScript("OnEvent", nil)
+	AlertFrame:RegisterEvent("SHOW_LOOT_TOAST")
 end
-

--- a/docs/OptionsReference.md
+++ b/docs/OptionsReference.md
@@ -96,6 +96,7 @@ Each action bar can be set to appear only on mouseover:
 - **Open the character frame when upgrading items at the vendor** (Open the character frame when upgrading items at the vendor).
 - **Quick loot items** (Quick loot items).
 - **Instant Catalyst button** (Instant Catalyst button).
+- **Enable custom loot toasts** (Enable custom loot toasts): suppresses all default loot toasts and only shows messages for items that meet your filters.
 
 ## Map Tools
 - **Enable /way command** (Enable /way command): provides a simple waypoint command if no other addon uses /way.


### PR DESCRIPTION
## Summary
- refine loot toast filtering to check mounts and pets by rarity
- show explanatory label for loot toast options
- document the new loot toast option
- add translation string for the label

## Testing
- `stylua EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Submodules/LootToast.lua EnhanceQoL/Locales/enUS.lua`

------
https://chatgpt.com/codex/tasks/task_e_68677431487c8329b27697bae7f706d9