### PR TITLE
Add loot category and init

### DIFF
--- a/EnhanceQoL/Locales/deDE.lua
+++ b/EnhanceQoL/Locales/deDE.lua
@@ -1,4 +1,5 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL", "deDE")
 if not L then return end
 
+L["Loot"] = "Beute"
 --@localization(locale="deDE", format="lua_additive_table")@

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -71,6 +71,7 @@ L["Character"] = "Character"
 L["Dungeon"] = "Dungeon"
 L["Misc"] = "Misc."
 L["Quest"] = "Quest"
+L["Loot"] = "Loot"
 
 L["hideBagsBar"] = "Hide Bagsbar"
 L["hideMicroMenu"] = "Hide Micro Menu"

--- a/EnhanceQoL/Locales/esES.lua
+++ b/EnhanceQoL/Locales/esES.lua
@@ -1,4 +1,5 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL", "esES")
 if not L then return end
 
+L["Loot"] = "Bot\195\173n"
 --@localization(locale="esES", format="lua_additive_table")@

--- a/EnhanceQoL/Locales/esMX.lua
+++ b/EnhanceQoL/Locales/esMX.lua
@@ -1,4 +1,5 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL", "esMX")
 if not L then return end
 
+L["Loot"] = "Bot\195\173n"
 --@localization(locale="esMX", format="lua_additive_table")@

--- a/EnhanceQoL/Locales/frFR.lua
+++ b/EnhanceQoL/Locales/frFR.lua
@@ -1,4 +1,5 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL", "frFR")
 if not L then return end
 
+L["Loot"] = "Butin"
 --@localization(locale="frFR", format="lua_additive_table")@

--- a/EnhanceQoL/Locales/itIT.lua
+++ b/EnhanceQoL/Locales/itIT.lua
@@ -1,4 +1,5 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL", "itIT")
 if not L then return end
 
+L["Loot"] = "Bottino"
 --@localization(locale="itIT", format="lua_additive_table")@

--- a/EnhanceQoL/Locales/koKR.lua
+++ b/EnhanceQoL/Locales/koKR.lua
@@ -1,4 +1,5 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL", "koKR")
 if not L then return end
 
+L["Loot"] = "\uc804\ub9ac\ud488"
 --@localization(locale="koKR", format="lua_additive_table")@

--- a/EnhanceQoL/Locales/ptBR.lua
+++ b/EnhanceQoL/Locales/ptBR.lua
@@ -1,4 +1,5 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL", "ptBR")
 if not L then return end
 
+L["Loot"] = "Saque"
 --@localization(locale="ptBR", format="lua_additive_table")@

--- a/EnhanceQoL/Locales/ruRU.lua
+++ b/EnhanceQoL/Locales/ruRU.lua
@@ -1,4 +1,5 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL", "ruRU")
 if not L then return end
 
+L["Loot"] = "\320\222\320\276\320\177\321\213\321\207\320\260"
 --@localization(locale="ruRU", format="lua_additive_table")@

--- a/EnhanceQoL/Locales/zhCN.lua
+++ b/EnhanceQoL/Locales/zhCN.lua
@@ -1,4 +1,5 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL", "zhCN")
 if not L then return end
 
+L["Loot"] = "\u62fe\u53d6"
 --@localization(locale="zhCN", format="lua_additive_table")@

--- a/EnhanceQoL/Locales/zhTW.lua
+++ b/EnhanceQoL/Locales/zhTW.lua
@@ -1,4 +1,5 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL", "zhTW")
 if not L then return end
 
+L["Loot"] = "\u62fe\u53d6"
 --@localization(locale="zhTW", format="lua_additive_table")@


### PR DESCRIPTION
## Summary
- localize new "Loot" tree label
- add new loot options frame and database init
- include loot frame in options tree and callback

## Testing
- `stylua EnhanceQoL/EnhanceQoL.lua`
- `luacheck ./EnhanceQoL/EnhanceQoL.lua`

------
https://chatgpt.com/codex/tasks/task_e_6867b85575b083298cd84257dd5cfb68