### PR TITLE
Implement rarity-specific loot filters

### DIFF
--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -100,13 +100,16 @@ L["Instant Catalyst"] = "Instant Catalyst"
 L["enableLootToastFilter"] = "Enable custom loot toasts"
 L["lootToastItemLevel"] = "Item level threshold"
 L["lootToastCheckIlvl"] = "Check item level"
-L["lootToastCheckRarity"] = "Check rarity"
-L["lootToastRarity"] = "Rarities"
 L["lootToastIncludeMounts"] = "Show for mounts"
 L["lootToastIncludePets"] = "Show for pets"
-L["lootToastIncludeLegendaries"] = "Show for legendaries"
 L["lootToastExplanation"] =
 	"Only loot toasts that match at least one filter will be shown. If rarity filtering is enabled the selected rarities also apply to mounts and pets. Item level is ignored for mounts and pets."
+
+L["Include"] = "Include"
+L["Add"] = "Add"
+L["Remove"] = "Remove"
+L["IncludeVendorList"] = "Itemlist"
+L["Item id or drag item"] = "Item id or drag item"
 
 L["headerClassInfo"] = "These settings only apply to %s"
 

--- a/EnhanceQoLAura/EnhanceQoLAura.lua
+++ b/EnhanceQoLAura/EnhanceQoLAura.lua
@@ -609,65 +609,83 @@ function addon.Aura.functions.treeCallback(container, group)
 	end
 end
 
-local BLACKLISTED_EVENTS = {
-	LOOT_ITEM_ROLL_WON = false,
-	LOOT_ITEM_ROLL_SELF = false,
-	LOOT_ITEM_ROLL_NEED = false,
-	LOOT_ITEM_ROLL_GREED = false,
-	LOOT_ITEM_ROLL_PASS = false,
-	LOOT_ITEM_SELF = false,
-	LOOT_ITEM_PUSHED_SELF = false,
-	SHOW_LOOT_TOAST = true,
-	SHOW_LOOT_TOAST_UPGRADE = false,
-	SHOW_LOOT_TOAST_LEGENDARY = false,
-}
-hooksecurefunc(AlertFrame, "RegisterEvent", function(self, event)
-	if BLACKLISTED_EVENTS[event] then xpcall(self.UnregisterEvent, self, event) end
-end)
+-- local BLACKLISTED_EVENTS = {
+-- 	LOOT_ITEM_ROLL_WON = false,
+-- 	LOOT_ITEM_ROLL_SELF = false,
+-- 	LOOT_ITEM_ROLL_NEED = false,
+-- 	LOOT_ITEM_ROLL_GREED = false,
+-- 	LOOT_ITEM_ROLL_PASS = false,
+-- 	LOOT_ITEM_SELF = false,
+-- 	LOOT_ITEM_PUSHED_SELF = false,
+-- 	SHOW_LOOT_TOAST = true,
+-- 	SHOW_LOOT_TOAST_UPGRADE = false,
+-- 	SHOW_LOOT_TOAST_LEGENDARY = false,
+-- }
+-- hooksecurefunc(AlertFrame, "RegisterEvent", function(self, event)
+-- 	if BLACKLISTED_EVENTS[event] then xpcall(self.UnregisterEvent, self, event) end
+-- end)
 
-local function errorHandler(err) return geterrorhandler()(err) end
+-- local function errorHandler(err) return geterrorhandler()(err) end
 
-for event, state in pairs(BLACKLISTED_EVENTS) do
-	if state and AlertFrame:IsEventRegistered(event) then AlertFrame:UnregisterEvent(event) end
-end
+-- for event, state in pairs(BLACKLISTED_EVENTS) do
+-- 	if state and AlertFrame:IsEventRegistered(event) then AlertFrame:UnregisterEvent(event) end
+-- end
 
-local blocker = CreateFrame("Frame")
-blocker:RegisterEvent("SHOW_LOOT_TOAST")
-blocker:SetScript("OnEvent", function(_, event, ...)
-	local typeIdentifier, itemLink, quantity, specID, _, _, _, lessAwesome, isUpgraded, isCorrupted = ...
-	if typeIdentifier == "item" then
-		local eItem = Item:CreateFromItemLink(itemLink)
-		if eItem and not eItem:IsItemEmpty() then
-			eItem:ContinueOnItemLoad(function()
-				local showToast = false
-				local bType = nil
-				if eItem:GetCurrentItemLevel() > 600 then showToast = true end
-				local _, _, itemQuality, _, _, _, _, _, itemEquipLoc, _, _, classID, subclassID = C_Item.GetItemInfo(eItem:GetItemLink())
-				if not showToast then
-					-- show mount loots
-					if classID == 15 and subclassID == 5 then showToast = true end
-					if itemQuality == 5 then showToast = true end
-					if not showToast then
-						local data = C_TooltipInfo.GetHyperlink(itemLink)
-						for i, v in pairs(data.lines) do
-							if v.type == 20 then
-								if v.leftText == ITEM_BIND_ON_EQUIP then
-									bType = "BoE"
-									showToast = true
-								elseif v.leftText == ITEM_ACCOUNTBOUND_UNTIL_EQUIP or v.leftText == ITEM_BIND_TO_ACCOUNT_UNTIL_EQUIP then
-									bType = "WuE"
-									showToast = true
-								elseif v.leftText == ITEM_ACCOUNTBOUND or v.leftText == ITEM_BIND_TO_BNETACCOUNT then
-									bType = "WB"
-									showToast = true
-								end
-								break
-							end
-						end
-					end
-				end
-				if showToast then LootAlertSystem:AddAlert(itemLink, quantity, nil, nil, specID, nil, nil, nil, lessAwesome, isUpgraded, isCorrupted) end
-			end)
-		end
-	end
-end)
+-- local blocker = CreateFrame("Frame")
+-- blocker:RegisterEvent("SHOW_LOOT_TOAST")
+-- blocker:SetScript("OnEvent", function(_, event, ...)
+-- 	local typeIdentifier, itemLink, quantity, specID, _, _, _, lessAwesome, isUpgraded, isCorrupted = ...
+-- 	if typeIdentifier == "item" then
+-- 		local eItem = Item:CreateFromItemLink(itemLink)
+-- 		if eItem and not eItem:IsItemEmpty() then
+-- 			eItem:ContinueOnItemLoad(function()
+-- 				local showToast = false
+-- 				local bType = nil
+-- 				if eItem:GetCurrentItemLevel() > 600 then showToast = true end
+-- 				local _, _, itemQuality, _, _, _, _, _, itemEquipLoc, _, _, classID, subclassID = C_Item.GetItemInfo(eItem:GetItemLink())
+-- 				if not showToast then
+-- 					-- show mount loots
+-- 					if classID == 15 and subclassID == 5 then showToast = true end
+-- 					if itemQuality == 5 then showToast = true end
+-- 					if not showToast then
+-- 						local data = C_TooltipInfo.GetHyperlink(itemLink)
+-- 						for i, v in pairs(data.lines) do
+-- 							if v.type == 20 then
+-- 								if v.leftText == ITEM_BIND_ON_EQUIP then
+-- 									bType = "BoE"
+-- 									showToast = true
+-- 								elseif v.leftText == ITEM_ACCOUNTBOUND_UNTIL_EQUIP or v.leftText == ITEM_BIND_TO_ACCOUNT_UNTIL_EQUIP then
+-- 									bType = "WuE"
+-- 									showToast = true
+-- 								elseif v.leftText == ITEM_ACCOUNTBOUND or v.leftText == ITEM_BIND_TO_BNETACCOUNT then
+-- 									bType = "WB"
+-- 									showToast = true
+-- 								end
+-- 								break
+-- 							end
+-- 						end
+-- 					end
+-- 				end
+-- 				if showToast then LootAlertSystem:AddAlert(itemLink, quantity, nil, nil, specID, nil, nil, nil, lessAwesome, isUpgraded, isCorrupted) end
+-- 			end)
+-- 		end
+-- 	end
+-- end)
+
+-- local ITEM_LINK_PATTERN = "|Hitem:.-|h%[.-%]|h|r"
+
+-- local myGUID = UnitGUID("player")
+
+-- local f = CreateFrame("Frame")
+-- f:RegisterEvent("CHAT_MSG_LOOT")
+-- f:SetScript("OnEvent", function(_, _, msg, _, _, _, _, _, _, _, _, _, _, guid)
+-- 	if guid ~= myGUID then return end -- fremden Loot überspringen
+-- 	local itemLink = msg:match(ITEM_LINK_PATTERN)
+-- 	if not itemLink then
+-- 		return -- war z. B. nur Gold / Währung
+-- 	end
+-- 	local quantity = tonumber(msg:match("x(%d+)")) or 1
+-- 	local itemID = tonumber(itemLink:match("item:(%d+)"))
+
+-- 	LootAlertSystem:AddAlert(itemLink, quantity, nil, nil, 0, nil, nil, nil, false, false, false)
+-- end)


### PR DESCRIPTION
## Summary
- add per-rarity filters for loot toasts
- allow custom item ID inclusion
- remove obsolete rarity dropdown logic

## Testing
- `stylua EnhanceQoL/Submodules/LootToast.lua EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`

------
https://chatgpt.com/codex/tasks/task_e_6868aee971348329a39556c8edb5f453