### PR TITLE
Improve LootToast include list feedback

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -2359,14 +2359,24 @@ local function addLootFrame(container, d)
 					end
 					if eItem and not eItem:IsItemEmpty() then
 						eItem:ContinueOnItemLoad(function()
+							local name = eItem:GetItemName()
+							if not name then
+								print(L["Item id does not exist"])
+								eBox:SetText("")
+								return
+							end
 							if not addon.db.lootToastIncludeIDs[eItem:GetItemID()] then
-								addon.db.lootToastIncludeIDs[eItem:GetItemID()] = eItem:GetItemName()
+								addon.db.lootToastIncludeIDs[eItem:GetItemID()] = string.format("%s (%d)", name, eItem:GetItemID())
 								local list, order = addon.functions.prepareListForDropdown(addon.db.lootToastIncludeIDs)
 								dropIncludeList:SetList(list, order)
 								dropIncludeList:SetValue(nil)
+								print(L["lootToastItemAdded"]:format(name, eItem:GetItemID()))
 							end
 							eBox:SetText("")
 						end)
+					else
+						print(L["Item id does not exist"])
+						eBox:SetText("")
 					end
 				end
 

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -116,6 +116,8 @@ L["Add"] = "Add"
 L["Remove"] = "Remove"
 L["IncludeVendorList"] = "Itemlist"
 L["Item id or drag item"] = "Item id or drag item"
+L["lootToastItemAdded"] = "Added %s (%d) to the include list"
+L["Item id does not exist"] = "Item id does not exist"
 
 L["headerClassInfo"] = "These settings only apply to %s"
 


### PR DESCRIPTION
## Summary
- show item IDs next to item names in the LootToast include list
- add chat feedback when items are added
- expose translation strings for the new messages

## Testing
- `luacheck EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`
- `stylua EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`

------
https://chatgpt.com/codex/tasks/task_e_6868c4ee1ec883299f6d2b4c83c8c375