### PR TITLE
Document loot toast feature

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -80,6 +80,8 @@ Fully configurable per context (combat, dungeon, friendly/enemy): items, item co
 *   Hideable Target Frame, Micro Menu (fade in on mouse-over).
 *   Profession-quality icon fade while searching.
 *   Quick-loot mode (disable Blizzard auto-loot for best speed).
+*   Custom loot toasts with item-level thresholds, mount/pet filtering,
+    include list and optional sound.
 *   Option to hide Raid Tools in party play.
 *   Disable Talking Head frame, plus other minor class-specific bar tweaks.
 *   **Enhanced Ignore List** – organise ignored players in a searchable window, highlight them in group finder and block unwanted requests. Toggle with `/eil`.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Fully configurable per context (combat, dungeon, friendly/enemy): items, item co
 *   Hideable Target Frame, Micro Menu (fade in on mouse-over).
 *   Profession-quality icon fade while searching.
 *   Quick-loot mode (disable Blizzard auto-loot for best speed).
+*   Custom loot toasts with item-level thresholds, mount/pet filtering,
+    include list and optional sound.
 *   Option to hide Raid Tools in party play.
 *   Disable Talking Head frame, plus other minor class-specific bar tweaks.
 

--- a/docs/OptionsReference.md
+++ b/docs/OptionsReference.md
@@ -96,9 +96,12 @@ Each action bar can be set to appear only on mouseover:
 - **Open the character frame when upgrading items at the vendor** (Open the character frame when upgrading items at the vendor).
 - **Quick loot items** (Quick loot items).
 - **Instant Catalyst button** (Instant Catalyst button).
-- **Enable custom loot toasts** (Enable custom loot toasts): suppresses all default loot toasts and only shows messages for items that meet your filters.
+- **Enable custom loot toasts** (Enable custom loot toasts): suppresses the default toast frame and only shows messages for items that pass your filters.
+- **Set item level thresholds per rarity** (Set item level thresholds per rarity): choose minimum item levels per quality before a toast appears.
+- **Show toasts for mounts** (Show for mounts): include mount drops in the filter.
+- **Show toasts for pets** (Show for pets): include pet drops in the filter.
+- **Include item IDs** (Itemlist): whitelist specific items regardless of other filters.
 - **Use custom loot sound** (Use custom loot sound): choose a custom sound for loot toasts.
-- **Set item level thresholds per rarity** (Set item level thresholds per rarity).
 
 ## Map Tools
 - **Enable /way command** (Enable /way command): provides a simple waypoint command if no other addon uses /way.


### PR DESCRIPTION
## Summary
- add bullet about customizable loot toasts with filters to README
- mirror that bullet in DESCRIPTION
- expand OptionsReference with loot toast checkboxes and filters

## Testing
- `luacheck . --no-color -q`

------
https://chatgpt.com/codex/tasks/task_e_6869830820048329b248a183d0f1d96b