### PR TITLE
Add option for favorites ignoring expansion hide

### DIFF
--- a/EnhanceQoLMythicPlus/DungeonPortal.lua
+++ b/EnhanceQoLMythicPlus/DungeonPortal.lua
@@ -335,8 +335,11 @@ local function CreatePortalCompendium(frame, compendium)
 	local newCompendium = {}
 	local favSpells = {}
 	for _, section in pairs(compendium) do
+		local hidden = addon.db["teleportsCompendiumHide" .. section.headline]
 		for spellID, data in pairs(section.spells) do
-			if favorites[spellID] then favSpells[spellID] = data end
+			if favorites[spellID] then
+				if addon.db.teleportFavoritesIgnoreExpansionHide or not hidden then favSpells[spellID] = data end
+			end
 		end
 	end
 	if next(favSpells) then newCompendium[9999] = { headline = L["Favorites"] or "Favorites", spells = favSpells } end

--- a/EnhanceQoLMythicPlus/EnhanceQoLMythicPlus.lua
+++ b/EnhanceQoLMythicPlus/EnhanceQoLMythicPlus.lua
@@ -756,6 +756,10 @@ local function addTeleportFrame(container)
 				text = L["portalShowMagePortal"],
 				var = "portalShowMagePortal",
 			},
+			{
+				text = L["teleportFavoritesIgnoreExpansionHide"],
+				var = "teleportFavoritesIgnoreExpansionHide",
+			},
 		}
 
 		for _, cbData in ipairs(data) do

--- a/EnhanceQoLMythicPlus/Init.lua
+++ b/EnhanceQoLMythicPlus/Init.lua
@@ -73,6 +73,7 @@ addon.functions.InitDBValue("portalHideMissing", false)
 addon.functions.InitDBValue("portalShowTooltip", false)
 addon.functions.InitDBValue("teleportsEnableCompendium", false)
 addon.functions.InitDBValue("teleportFavorites", {})
+addon.functions.InitDBValue("teleportFavoritesIgnoreExpansionHide", false)
 
 -- Group Dungeon Filter
 addon.functions.InitDBValue("mythicPlusEnableDungeonFilter", false)

--- a/EnhanceQoLMythicPlus/Locales/enUS.lua
+++ b/EnhanceQoLMythicPlus/Locales/enUS.lua
@@ -84,6 +84,7 @@ L["portalShowEngineering"] = "Show Engineering Teleports (Requires Engineering)"
 L["portalShowClassTeleport"] = "Show Class-Specific Teleports (Only if this class has any)"
 L["portalShowMagePortal"] = "Show Mage Portals (Mage only)"
 L["Favorites"] = "Favorites"
+L["teleportFavoritesIgnoreExpansionHide"] = "Always show favorites from hidden expansions"
 
 -- BR Tracker
 L["BRTracker"] = "Combat Resurrection"


### PR DESCRIPTION
## Summary
- add DB flag `teleportFavoritesIgnoreExpansionHide`
- allow toggling the flag via a new checkbox
- when enabled, favorites from hidden expansions still show in the teleport compendium

## Testing
- `stylua EnhanceQoLMythicPlus/Init.lua EnhanceQoLMythicPlus/Locales/enUS.lua EnhanceQoLMythicPlus/DungeonPortal.lua EnhanceQoLMythicPlus/EnhanceQoLMythicPlus.lua`

------
https://chatgpt.com/codex/tasks/task_e_68708ec5de088329a9f9c12decdb7482