### PR TITLE
Fix hearthstone favoriting

### DIFF
--- a/EnhanceQoLMythicPlus/DungeonPortal.lua
+++ b/EnhanceQoLMythicPlus/DungeonPortal.lua
@@ -256,10 +256,12 @@ local function CreatePortalButtonsWithCooldown(frame, spells)
 			button.cooldownFrame:SetAllPoints(button)
 
 			-- Sichere Aktion (CastSpell)
-			button:SetAttribute("type", "spell")
-			button:SetAttribute("spell", spellID)
+                        button:SetAttribute("type1", "spell")
+                        button:SetAttribute("spell1", spellID)
+                        button:SetAttribute("type2", nil)
+                        button:SetAttribute("spell2", nil)
 
-			button:RegisterForClicks("AnyUp", "AnyDown")
+                        button:RegisterForClicks("LeftButtonUp", "RightButtonUp")
 			button:SetScript("OnMouseUp", function(self, btn)
 				if btn == "RightButton" then
 					local favs = addon.db.teleportFavorites
@@ -536,21 +538,27 @@ local function CreatePortalCompendium(frame, compendium)
 				button.cooldownFrame:SetAllPoints(button)
 
 				-- Sichere Aktion (CastSpell)
-				if spellData.isToy then
-					if spellData.isKnown then
-						button:SetAttribute("type", "macro")
-						button:SetAttribute("macrotext", "/use item:" .. spellData.toyID)
-					end
-				elseif spellData.isItem then
-					if spellData.isKnown then
-						button:SetAttribute("type", "macro")
-						button:SetAttribute("macrotext", "/use item:" .. spellData.itemID)
-					end
-				else
-					button:SetAttribute("type", "spell")
-					button:SetAttribute("spell", spellID)
-				end
-				button:RegisterForClicks("AnyUp", "AnyDown")
+                                if spellData.isToy then
+                                        if spellData.isKnown then
+                                                button:SetAttribute("type1", "macro")
+                                                button:SetAttribute("macrotext1", "/use item:" .. spellData.toyID)
+                                                button:SetAttribute("type2", nil)
+                                                button:SetAttribute("macrotext2", nil)
+                                        end
+                                elseif spellData.isItem then
+                                        if spellData.isKnown then
+                                                button:SetAttribute("type1", "macro")
+                                                button:SetAttribute("macrotext1", "/use item:" .. spellData.itemID)
+                                                button:SetAttribute("type2", nil)
+                                                button:SetAttribute("macrotext2", nil)
+                                        end
+                                else
+                                        button:SetAttribute("type1", "spell")
+                                        button:SetAttribute("spell1", spellID)
+                                        button:SetAttribute("type2", nil)
+                                        button:SetAttribute("spell2", nil)
+                                end
+                                button:RegisterForClicks("LeftButtonUp", "RightButtonUp")
 				button:SetScript("OnMouseUp", function(self, btn)
 					if btn == "RightButton" then
 						local favs = addon.db.teleportFavorites

--- a/EnhanceQoLMythicPlus/Init.lua
+++ b/EnhanceQoLMythicPlus/Init.lua
@@ -605,6 +605,7 @@ addon.MythicPlus.variables.portalCompendium = {
 }
 
 -- Pre-Stage all icon to have less calls to LUA API
+local RANDOM_HS_ID = 999999
 local hearthstoneID = {
 	{ isToy = true, icon = 4622300, id = 235016, spellID = 1217281 }, -- Redeployment Module
 	{ isItem = true, icon = 134414, id = 6948, spellID = 8690 }, -- Default Hearthstone
@@ -680,13 +681,20 @@ function addon.MythicPlus.functions.setRandomHearthstone()
 		if #availableHearthstones == 0 then return nil end
 	end
 
-	local randomIndex = math.random(1, #availableHearthstones)
+        local randomIndex = math.random(1, #availableHearthstones)
 
-	local hs = availableHearthstones[randomIndex]
-	local hsSpellID = hs.spellID or 1
-	addon.MythicPlus.variables.portalCompendium[11].spells = {
-		[hsSpellID] = { text = "HS", isItem = false or hs.isItem, itemID = hs.id, isToy = false or hs.isToy, toyID = hs.id, isHearthstone = true, icon = hs.icon },
-	}
+        local hs = availableHearthstones[randomIndex]
+        addon.MythicPlus.variables.portalCompendium[11].spells = {
+                [RANDOM_HS_ID] = {
+                        text = "HS",
+                        isItem = hs.isItem or false,
+                        itemID = hs.id,
+                        isToy = hs.isToy or false,
+                        toyID = hs.id,
+                        isHearthstone = true,
+                        icon = hs.icon,
+                },
+        }
 end
 
 addon.MythicPlus.variables.collapseFrames = {


### PR DESCRIPTION
## Summary
- keep random hearthstone entry constant so it can be favourited
- avoid casting when right-click toggling favorites

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6870942f21d883299dacca8ef7ce340c