### PR TITLE
Add AltInventory submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.27.1] – 2025-07-11
+### ✨ Added
+- Search box for filtering the alt‑inventory viewer.
+### 🐛 Bug Fixes
+- Item tooltips now show when hovering entries in the alt‑inventory viewer.
+- Fixed an error when toggling the alt‑inventory viewer.
+
 ## [3.27.0] – 2025-07-11
 ### ✨ Added
 - **Teleport Favorites in the Compendium**

--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -4705,8 +4705,9 @@ local eventHandlers = {
 			loadSubAddon("EnhanceQoLSound")
 			loadSubAddon("EnhanceQoLMouse")
 			loadSubAddon("EnhanceQoLMythicPlus")
-			loadSubAddon("EnhanceQoLDrinkMacro")
-			loadSubAddon("EnhanceQoLTooltip")
+                        loadSubAddon("EnhanceQoLDrinkMacro")
+                        loadSubAddon("EnhanceQoLAltInventory")
+                        loadSubAddon("EnhanceQoLTooltip")
 			loadSubAddon("EnhanceQoLVendor")
 
 			checkBagIgnoreJunk()

--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -4508,7 +4508,8 @@ function loadMain()
 	SLASH_ENHANCEQOL4 = "/eqol rag"
 	SLASH_ENHANCEQOL5 = "/eqol lag"
 	SLASH_ENHANCEQOL6 = "/eqol lcid"
-	SLASH_ENHANCEQOL6 = "/eqol rq"
+	SLASH_ENHANCEQOL7 = "/eqol rq"
+	SLASH_ENHANCEQOL8 = "/eqol altinv"
 	SlashCmdList["ENHANCEQOL"] = function(msg)
 		if msg == "resetframe" then
 			-- Frame zurücksetzen
@@ -4550,6 +4551,8 @@ function loadMain()
 			end
 		elseif msg == "rq" then
 			if addon.Query and addon.Query.frame then addon.Query.frame:Show() end
+		elseif msg == "altinv" then
+			if addon.AltInventory and addon.AltInventory.ToggleFrame then addon.AltInventory:ToggleFrame() end
 		else
 			if addon.aceFrame:IsShown() then
 				addon.aceFrame:Hide()
@@ -4705,9 +4708,9 @@ local eventHandlers = {
 			loadSubAddon("EnhanceQoLSound")
 			loadSubAddon("EnhanceQoLMouse")
 			loadSubAddon("EnhanceQoLMythicPlus")
-                        loadSubAddon("EnhanceQoLDrinkMacro")
-                        loadSubAddon("EnhanceQoLAltInventory")
-                        loadSubAddon("EnhanceQoLTooltip")
+			loadSubAddon("EnhanceQoLDrinkMacro")
+			loadSubAddon("EnhanceQoLAltInventory")
+			loadSubAddon("EnhanceQoLTooltip")
 			loadSubAddon("EnhanceQoLVendor")
 
 			checkBagIgnoreJunk()

--- a/EnhanceQoLAltInventory/AltInventory.lua
+++ b/EnhanceQoLAltInventory/AltInventory.lua
@@ -1,5 +1,17 @@
+local parentAddonName = "EnhanceQoL"
 local addonName, addon = ...
-if not addon then addon = _G["EnhanceQoL"] end
+
+if _G[parentAddonName] then
+	addon = _G[parentAddonName]
+else
+	error(parentAddonName .. " is not loaded")
+end
+
+local L = LibStub("AceLocale-3.0"):GetLocale("EnhanceQoL_AltInventory")
+
+local AceGUI = addon.AceGUI
+
+local sUI = false
 
 -- Module table
 local AltInventory = addon.AltInventory or {}

--- a/EnhanceQoLAltInventory/AltInventory.lua
+++ b/EnhanceQoLAltInventory/AltInventory.lua
@@ -5,4 +5,48 @@ if not addon then addon = _G["EnhanceQoL"] end
 local AltInventory = addon.AltInventory or {}
 addon.AltInventory = AltInventory
 
--- Add your Alt Inventory functionality here
+local function update()
+	if not addon.db.altInventory then addon.db.altInventory = {} end
+
+	local guid = UnitGUID("player")
+	if not guid then return end
+
+	local data = {}
+
+	local function scanBag(bag)
+		for slot = 1, C_Container.GetContainerNumSlots(bag) do
+			local info = C_Container.GetContainerItemInfo(bag, slot)
+			if info and info.stackCount and info.stackCount > 0 then
+				local link = C_Container.GetContainerItemLink(bag, slot)
+				if link then data[link] = (data[link] or 0) + info.stackCount end
+			end
+		end
+	end
+
+	-- bags
+	for bag = BACKPACK_CONTAINER, NUM_TOTAL_EQUIPPED_BAG_SLOTS do
+		scanBag(bag)
+	end
+
+	-- bank
+	scanBag(BANK_CONTAINER)
+	for bag = NUM_BAG_SLOTS + 1, NUM_BAG_SLOTS + NUM_BANKBAGSLOTS do
+		scanBag(bag)
+	end
+
+	if IsReagentBankUnlocked() then scanBag(REAGENTBANK_CONTAINER) end
+
+	addon.db.altInventory[guid] = data
+end
+
+local eventHandlers = {
+	PLAYER_ENTERING_WORLD = update,
+	BAG_UPDATE_DELAYED = update,
+	BANKFRAME_CLOSED = update,
+}
+
+local frame = CreateFrame("Frame")
+for e in pairs(eventHandlers) do
+	frame:RegisterEvent(e)
+end
+frame:SetScript("OnEvent", function(_, event) eventHandlers[event]() end)

--- a/EnhanceQoLAltInventory/AltInventory.lua
+++ b/EnhanceQoLAltInventory/AltInventory.lua
@@ -7,6 +7,7 @@ addon.AltInventory = AltInventory
 
 local function update()
 	if not addon.db.altInventory then addon.db.altInventory = {} end
+	if not addon.db.altInventoryNames then addon.db.altInventoryNames = {} end
 
 	local guid = UnitGUID("player")
 	if not guid then return end
@@ -37,6 +38,8 @@ local function update()
 	if IsReagentBankUnlocked() then scanBag(REAGENTBANK_CONTAINER) end
 
 	addon.db.altInventory[guid] = data
+	local name = GetUnitName("player", true)
+	addon.db.altInventoryNames[guid] = name
 end
 
 local eventHandlers = {

--- a/EnhanceQoLAltInventory/AltInventory.lua
+++ b/EnhanceQoLAltInventory/AltInventory.lua
@@ -1,0 +1,8 @@
+local addonName, addon = ...
+if not addon then addon = _G["EnhanceQoL"] end
+
+-- Module table
+local AltInventory = addon.AltInventory or {}
+addon.AltInventory = AltInventory
+
+-- Add your Alt Inventory functionality here

--- a/EnhanceQoLAltInventory/EnhanceQoLAltInventory.toc
+++ b/EnhanceQoLAltInventory/EnhanceQoLAltInventory.toc
@@ -1,0 +1,14 @@
+## Interface: 110000, 110002, 110005, 110007, 110100, 110105, 110107, 110200
+## Title: Alt Inventory
+## Author: R41Z0R
+## Version: @project-version@
+## Notes: Manage and view alt inventory items
+## Dependencies: EnhanceQoL
+## IconTexture: Interface\\AddOns\\EnhanceQoL\\Icons\\Icon.tga
+## Retail: true
+## X-Compatible-With: retail
+## LoadOnDemand: 1
+## Globe-Main: EnhanceQoL
+
+Init.lua
+AltInventory.lua

--- a/EnhanceQoLAltInventory/EnhanceQoLAltInventory.toc
+++ b/EnhanceQoLAltInventory/EnhanceQoLAltInventory.toc
@@ -11,5 +11,6 @@
 ## Globe-Main: EnhanceQoL
 
 Init.lua
+locales.xml
 AltInventory.lua
 UI.lua

--- a/EnhanceQoLAltInventory/EnhanceQoLAltInventory.toc
+++ b/EnhanceQoLAltInventory/EnhanceQoLAltInventory.toc
@@ -12,3 +12,4 @@
 
 Init.lua
 AltInventory.lua
+UI.lua

--- a/EnhanceQoLAltInventory/Init.lua
+++ b/EnhanceQoLAltInventory/Init.lua
@@ -1,0 +1,12 @@
+local parentAddonName = "EnhanceQoL"
+local addonName, addon = ...
+if _G[parentAddonName] then
+	addon = _G[parentAddonName]
+else
+	error(parentAddonName .. " is not loaded")
+end
+
+addon.AltInventory = addon.AltInventory or {}
+addon.AltInventory.functions = addon.AltInventory.functions or {}
+
+addon.functions.InitDBValue("altInventory", {})

--- a/EnhanceQoLAltInventory/Locales/deDE.lua
+++ b/EnhanceQoLAltInventory/Locales/deDE.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "deDE")
+if not L then return end
+
+--@localization(locale="deDE", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/enUS.lua
+++ b/EnhanceQoLAltInventory/Locales/enUS.lua
@@ -1,0 +1,8 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "enUS", true)
+
+L["Alt Inventory"] = "Alt Inventory"
+L["By Item"] = "By Item"
+L["By Character"] = "By Character"
+L["Total"] = "Total"
+L["AltInventoryTooltip"] = "|cffeda55fClick|r to toggle Alt Inventory"
+

--- a/EnhanceQoLAltInventory/Locales/enUS.lua
+++ b/EnhanceQoLAltInventory/Locales/enUS.lua
@@ -5,4 +5,5 @@ L["By Item"] = "By Item"
 L["By Character"] = "By Character"
 L["Total"] = "Total"
 L["AltInventoryTooltip"] = "|cffeda55fClick|r to toggle Alt Inventory"
+L["Search"] = "Search"
 

--- a/EnhanceQoLAltInventory/Locales/esES.lua
+++ b/EnhanceQoLAltInventory/Locales/esES.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "esES")
+if not L then return end
+
+--@localization(locale="esES", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/esMX.lua
+++ b/EnhanceQoLAltInventory/Locales/esMX.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "esMX")
+if not L then return end
+
+--@localization(locale="esMX", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/frFR.lua
+++ b/EnhanceQoLAltInventory/Locales/frFR.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "frFR")
+if not L then return end
+
+--@localization(locale="frFR", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/itIT.lua
+++ b/EnhanceQoLAltInventory/Locales/itIT.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "itIT")
+if not L then return end
+
+--@localization(locale="itIT", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/koKR.lua
+++ b/EnhanceQoLAltInventory/Locales/koKR.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "koKR")
+if not L then return end
+
+--@localization(locale="koKR", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/ptBR.lua
+++ b/EnhanceQoLAltInventory/Locales/ptBR.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "ptBR")
+if not L then return end
+
+--@localization(locale="ptBR", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/ruRU.lua
+++ b/EnhanceQoLAltInventory/Locales/ruRU.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "ruRU")
+if not L then return end
+
+--@localization(locale="ruRU", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/zhCN.lua
+++ b/EnhanceQoLAltInventory/Locales/zhCN.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "zhCN")
+if not L then return end
+
+--@localization(locale="zhCN", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/zhTW.lua
+++ b/EnhanceQoLAltInventory/Locales/zhTW.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "zhTW")
+if not L then return end
+
+--@localization(locale="zhTW", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/UI.lua
+++ b/EnhanceQoLAltInventory/UI.lua
@@ -17,10 +17,8 @@ local AltInventory = addon.AltInventory or {}
 
 local function getItemInfoFromLink(link)
 	if not link then return end
-	local tipData = C_TooltipInfo.GetHyperlink(link)
-	if not tipData then return end
-	TooltipUtil.SurfaceArgs(tipData)
-	return tipData.name, tipData.icon, tipData.quality
+	local itemName, _, itemQuality, _, _, _, _, _, _, itemTexture = C_Item.GetItemInfo(link)
+	return itemName, itemTexture, itemQuality
 end
 
 local function buildByItem(container)

--- a/EnhanceQoLAltInventory/UI.lua
+++ b/EnhanceQoLAltInventory/UI.lua
@@ -1,0 +1,112 @@
+-- luacheck: globals TooltipUtil
+local parentAddonName = "EnhanceQoL"
+local addonName, addon = ...
+if not addon then addon = _G[parentAddonName] end
+
+local AceGUI = LibStub("AceGUI-3.0")
+
+local AltInventory = addon.AltInventory or {}
+addon.AltInventory = AltInventory
+
+local frame
+local tabGroup
+
+local function getItemInfoFromLink(link)
+	if not link then return end
+	local tipData = C_TooltipInfo.GetHyperlink(link)
+	if not tipData then return end
+	TooltipUtil.SurfaceArgs(tipData)
+	return tipData.name, tipData.icon, tipData.quality
+end
+
+local function buildByItem(container)
+	local aggregated = {}
+	for guid, items in pairs(addon.db.altInventory or {}) do
+		for link, count in pairs(items) do
+			if not aggregated[link] then aggregated[link] = { total = 0, chars = {} } end
+			aggregated[link].total = aggregated[link].total + count
+			aggregated[link].chars[guid] = count
+		end
+	end
+
+	local tree = {}
+	for link, data in pairs(aggregated) do
+		local name, icon, quality = getItemInfoFromLink(link)
+		local colorHex = select(4, GetItemQualityColor(quality or 1))
+		local text = string.format("|T%s:0|t |c%s%s|r x%d", icon or "", colorHex, name or link, data.total)
+		local node = { value = link, text = text, children = {} }
+		for guid, count in pairs(data.chars) do
+			local charName = addon.db.altInventoryNames and addon.db.altInventoryNames[guid] or guid
+			table.insert(node.children, { value = link .. guid, text = string.format("%s x%d", charName, count) })
+		end
+		table.sort(node.children, function(a, b) return a.text < b.text end)
+		table.insert(tree, node)
+	end
+	table.sort(tree, function(a, b) return a.text < b.text end)
+
+	local tg = AceGUI:Create("TreeGroup")
+	tg:SetFullWidth(true)
+	tg:SetFullHeight(true)
+	tg:SetTree(tree)
+	container:AddChild(tg)
+end
+
+local function buildByChar(container)
+	local tree = {}
+	for guid, items in pairs(addon.db.altInventory or {}) do
+		local charName = addon.db.altInventoryNames and addon.db.altInventoryNames[guid] or guid
+		local node = { value = guid, text = charName, children = {} }
+		for link, count in pairs(items) do
+			local name, icon, quality = getItemInfoFromLink(link)
+			local colorHex = select(4, GetItemQualityColor(quality or 1))
+			local childText = string.format("|T%s:0|t |c%s%s|r x%d", icon or "", colorHex, name or link, count)
+			table.insert(node.children, { value = guid .. link, text = childText })
+		end
+		table.sort(node.children, function(a, b) return a.text < b.text end)
+		table.insert(tree, node)
+	end
+	table.sort(tree, function(a, b) return a.text < b.text end)
+
+	local tg = AceGUI:Create("TreeGroup")
+	tg:SetFullWidth(true)
+	tg:SetFullHeight(true)
+	tg:SetTree(tree)
+	container:AddChild(tg)
+end
+
+local function buildTab(container, group)
+	container:ReleaseChildren()
+	if group == "byitem" then
+		buildByItem(container)
+	else
+		buildByChar(container)
+	end
+end
+
+function AltInventory:CreateFrame()
+	if frame then return frame end
+	frame = AceGUI:Create("Frame")
+	frame:SetTitle("Alt Inventory")
+	frame:SetWidth(500)
+	frame:SetHeight(600)
+	frame:SetLayout("Fill")
+	frame.frame:Hide()
+
+	tabGroup = AceGUI:Create("TabGroup")
+	tabGroup:SetLayout("Fill")
+	tabGroup:SetTabs({ { text = "By Item", value = "byitem" }, { text = "By Character", value = "bychar" } })
+	tabGroup:SetCallback("OnGroupSelected", buildTab)
+	frame:AddChild(tabGroup)
+	tabGroup:SelectTab("byitem")
+	return frame
+end
+
+function AltInventory:ToggleFrame()
+	if not frame then self:CreateFrame() end
+	if frame.frame:IsShown() then
+		frame.frame:Hide()
+	else
+		frame.frame:Show()
+		buildTab(tabGroup, tabGroup:GetSelectedTab() or "byitem")
+	end
+end

--- a/EnhanceQoLAltInventory/UI.lua
+++ b/EnhanceQoLAltInventory/UI.lua
@@ -1,15 +1,19 @@
--- luacheck: globals TooltipUtil
 local parentAddonName = "EnhanceQoL"
 local addonName, addon = ...
-if not addon then addon = _G[parentAddonName] end
 
-local AceGUI = LibStub("AceGUI-3.0")
+if _G[parentAddonName] then
+	addon = _G[parentAddonName]
+else
+	error(parentAddonName .. " is not loaded")
+end
 
-local AltInventory = addon.AltInventory or {}
-addon.AltInventory = AltInventory
+local L = LibStub("AceLocale-3.0"):GetLocale("EnhanceQoL_AltInventory")
+
+local AceGUI = addon.AceGUI
 
 local frame
 local tabGroup
+local AltInventory = addon.AltInventory or {}
 
 local function getItemInfoFromLink(link)
 	if not link then return end
@@ -110,3 +114,5 @@ function AltInventory:ToggleFrame()
 		buildTab(tabGroup, tabGroup:GetSelectedTab() or "byitem")
 	end
 end
+
+print("drin")

--- a/EnhanceQoLAltInventory/locales.xml
+++ b/EnhanceQoLAltInventory/locales.xml
@@ -1,0 +1,16 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
+
+<Script file="Locales\\enUS.lua"/>
+<Script file="Locales\\deDE.lua"/>
+<Script file="Locales\\frFR.lua"/>
+<Script file="Locales\\esES.lua"/>
+<Script file="Locales\\esMX.lua"/>
+<Script file="Locales\\koKR.lua"/>
+<Script file="Locales\\zhCN.lua"/>
+<Script file="Locales\\zhTW.lua"/>
+<Script file="Locales\\ruRU.lua"/>
+<Script file="Locales\\ptBR.lua"/>
+<Script file="Locales\\itIT.lua"/>
+
+</Ui>
+

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Every feature can be switched off; footprint is negligible.
 | Command          |Action                                           |
 | ---------------- |------------------------------------------------ |
 | <code>/eqol</code> |Open the configuration window                    |
-| <code>/eqol resetframe</code> |Re-center all Enhance QoL windows                |
-| <code>/eqol lag</code> |List gossip IDs of the current NPC dialog        |
+| <code>/eqol resetframe</code> |Re-center all Enhance QoL windows |
+| <code>/eqol lag</code> |List gossip IDs of the current NPC dialog |
 | <code>/eqol aag &lt;id&gt;</code> |Auto-pick a gossip option (chosen via <code>/eqol lag</code>) |
-| <code>/eqol rag &lt;id&gt;</code> |Remove an auto-picked gossip ID                  |
-
+| <code>/eqol rag &lt;id&gt;</code> |Remove an auto-picked gossip ID |
+| <code>/eqol altinv</code> |Toggle the alt-inventory viewer |
 ***
 
 ## Supported Languages

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ English • German • French • Spanish • Italian • Russian • Korean •
 *   Hideable Bag Bar (mouse-over).
 *   Money tracker – total gold for all characters in one tooltip.
 *   Alt-inventory cache – counts how many of each item your alts own.
+*   Alt-inventory viewer – `/eqol altinv` shows which character holds each item. Counts are stored automatically when bags update.
 
 ### Character & Inspect
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,6 +15,7 @@ EnhanceQoL_MYTHIC_PLUS_QUERY_DIR="$WOW_ADDON_DIR/EnhanceQoLMythicPlus"
 EnhanceQoL_SOUND_QUERY_DIR="$WOW_ADDON_DIR/EnhanceQoLSound"
 EnhanceQoL_TOOLTIP_QUERY_DIR="$WOW_ADDON_DIR/EnhanceQoLTooltip"
 EnhanceQoL_VENDOR_QUERY_DIR="$WOW_ADDON_DIR/EnhanceQoLVendor"
+EnhanceQoL_ALT_INVENTORY_DIR="$WOW_ADDON_DIR/EnhanceQoLAltInventory"
 
 VERSION=$(git describe --tags --always)
 
@@ -29,6 +30,7 @@ rm -rf "$EnhanceQoL_MYTHIC_PLUS_QUERY_DIR"
 rm -rf "$EnhanceQoL_SOUND_QUERY_DIR"
 rm -rf "$EnhanceQoL_TOOLTIP_QUERY_DIR"
 rm -rf "$EnhanceQoL_VENDOR_QUERY_DIR"
+rm -rf "$EnhanceQoL_ALT_INVENTORY_DIR"
 
 # Erstelle die Addon-Verzeichnisse neu
 mkdir -p "$EnhanceQoL_ADDON_DIR"
@@ -41,6 +43,7 @@ mkdir -p "$EnhanceQoL_MYTHIC_PLUS_QUERY_DIR"
 mkdir -p "$EnhanceQoL_SOUND_QUERY_DIR"
 mkdir -p "$EnhanceQoL_TOOLTIP_QUERY_DIR"
 mkdir -p "$EnhanceQoL_VENDOR_QUERY_DIR"
+mkdir -p "$EnhanceQoL_ALT_INVENTORY_DIR"
 
 echo "$ROOT_DIR"
 
@@ -55,6 +58,7 @@ cp -r "$ROOT_DIR/EnhanceQoLMythicPlus/"* "$EnhanceQoL_MYTHIC_PLUS_QUERY_DIR/"
 cp -r "$ROOT_DIR/EnhanceQoLSound/"* "$EnhanceQoL_SOUND_QUERY_DIR/"
 cp -r "$ROOT_DIR/EnhanceQoLTooltip/"* "$EnhanceQoL_TOOLTIP_QUERY_DIR/"
 cp -r "$ROOT_DIR/EnhanceQoLVendor/"* "$EnhanceQoL_VENDOR_QUERY_DIR/"
+cp -r "$ROOT_DIR/EnhanceQoLAltInventory/"* "$EnhanceQoL_ALT_INVENTORY_DIR/"
 
 # Version in den .toc-Dateien ersetzen
 sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_ADDON_DIR/EnhanceQoL.toc"
@@ -67,5 +71,6 @@ sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_MYTHIC_PLUS_QUERY_DIR/Enh
 sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_SOUND_QUERY_DIR/EnhanceQoLSound.toc"
 sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_TOOLTIP_QUERY_DIR/EnhanceQoLTooltip.toc"
 sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_VENDOR_QUERY_DIR/EnhanceQoLVendor.toc"
+sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_ALT_INVENTORY_DIR/EnhanceQoLAltInventory.toc"
 
 echo "Addons wurden nach $WOW_ADDON_DIR kopiert."

--- a/scripts/buildPTR.sh
+++ b/scripts/buildPTR.sh
@@ -15,6 +15,7 @@ EnhanceQoL_MYTHIC_PLUS_QUERY_DIR="$WOW_ADDON_DIR/EnhanceQoLMythicPlus"
 EnhanceQoL_SOUND_QUERY_DIR="$WOW_ADDON_DIR/EnhanceQoLSound"
 EnhanceQoL_TOOLTIP_QUERY_DIR="$WOW_ADDON_DIR/EnhanceQoLTooltip"
 EnhanceQoL_VENDOR_QUERY_DIR="$WOW_ADDON_DIR/EnhanceQoLVendor"
+EnhanceQoL_ALT_INVENTORY_DIR="$WOW_ADDON_DIR/EnhanceQoLAltInventory"
 
 VERSION=$(git describe --tags --always)
 
@@ -29,6 +30,7 @@ rm -rf "$EnhanceQoL_MYTHIC_PLUS_QUERY_DIR"
 rm -rf "$EnhanceQoL_SOUND_QUERY_DIR"
 rm -rf "$EnhanceQoL_TOOLTIP_QUERY_DIR"
 rm -rf "$EnhanceQoL_VENDOR_QUERY_DIR"
+rm -rf "$EnhanceQoL_ALT_INVENTORY_DIR"
 
 # Erstelle die Addon-Verzeichnisse neu
 mkdir -p "$EnhanceQoL_ADDON_DIR"
@@ -41,6 +43,7 @@ mkdir -p "$EnhanceQoL_MYTHIC_PLUS_QUERY_DIR"
 mkdir -p "$EnhanceQoL_SOUND_QUERY_DIR"
 mkdir -p "$EnhanceQoL_TOOLTIP_QUERY_DIR"
 mkdir -p "$EnhanceQoL_VENDOR_QUERY_DIR"
+mkdir -p "$EnhanceQoL_ALT_INVENTORY_DIR"
 
 echo "$ROOT_DIR"
 
@@ -55,6 +58,7 @@ cp -r "$ROOT_DIR/EnhanceQoLMythicPlus/"* "$EnhanceQoL_MYTHIC_PLUS_QUERY_DIR/"
 cp -r "$ROOT_DIR/EnhanceQoLSound/"* "$EnhanceQoL_SOUND_QUERY_DIR/"
 cp -r "$ROOT_DIR/EnhanceQoLTooltip/"* "$EnhanceQoL_TOOLTIP_QUERY_DIR/"
 cp -r "$ROOT_DIR/EnhanceQoLVendor/"* "$EnhanceQoL_VENDOR_QUERY_DIR/"
+cp -r "$ROOT_DIR/EnhanceQoLAltInventory/"* "$EnhanceQoL_ALT_INVENTORY_DIR/"
 
 # Version in den .toc-Dateien ersetzen
 sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_ADDON_DIR/EnhanceQoL.toc"
@@ -67,5 +71,6 @@ sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_MYTHIC_PLUS_QUERY_DIR/Enh
 sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_SOUND_QUERY_DIR/EnhanceQoLSound.toc"
 sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_TOOLTIP_QUERY_DIR/EnhanceQoLTooltip.toc"
 sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_VENDOR_QUERY_DIR/EnhanceQoLVendor.toc"
+sed -i '' "s/@project-version@/$VERSION/" "$EnhanceQoL_ALT_INVENTORY_DIR/EnhanceQoLAltInventory.toc"
 
 echo "Addons wurden nach $WOW_ADDON_DIR kopiert."


### PR DESCRIPTION
## Summary
- add `EnhanceQoLAltInventory` folder with TOC and Lua files
- register DB defaults for alt inventory
- load the new sub-addon from core

## Testing
- `luacheck EnhanceQoLAltInventory/Init.lua EnhanceQoLAltInventory/AltInventory.lua`
- `stylua --check EnhanceQoLAltInventory/Init.lua EnhanceQoLAltInventory/AltInventory.lua`


------
https://chatgpt.com/codex/tasks/task_e_6870bfd58cb48329a8e89c589875e8d2