### PR TITLE
Implement alt inventory tracking

### DIFF
--- a/EnhanceQoLAltInventory/AltInventory.lua
+++ b/EnhanceQoLAltInventory/AltInventory.lua
@@ -5,4 +5,48 @@ if not addon then addon = _G["EnhanceQoL"] end
 local AltInventory = addon.AltInventory or {}
 addon.AltInventory = AltInventory
 
--- Add your Alt Inventory functionality here
+local function update()
+	if not addon.db.altInventory then addon.db.altInventory = {} end
+
+	local guid = UnitGUID("player")
+	if not guid then return end
+
+	local data = {}
+
+	local function scanBag(bag)
+		for slot = 1, C_Container.GetContainerNumSlots(bag) do
+			local info = C_Container.GetContainerItemInfo(bag, slot)
+			if info and info.stackCount and info.stackCount > 0 then
+				local link = C_Container.GetContainerItemLink(bag, slot)
+				if link then data[link] = (data[link] or 0) + info.stackCount end
+			end
+		end
+	end
+
+	-- bags
+	for bag = BACKPACK_CONTAINER, NUM_TOTAL_EQUIPPED_BAG_SLOTS do
+		scanBag(bag)
+	end
+
+	-- bank
+	scanBag(BANK_CONTAINER)
+	for bag = NUM_BAG_SLOTS + 1, NUM_BAG_SLOTS + NUM_BANKBAGSLOTS do
+		scanBag(bag)
+	end
+
+	if IsReagentBankUnlocked() then scanBag(REAGENTBANK_CONTAINER) end
+
+	addon.db.altInventory[guid] = data
+end
+
+local eventHandlers = {
+	PLAYER_ENTERING_WORLD = update,
+	BAG_UPDATE_DELAYED = update,
+	BANKFRAME_CLOSED = update,
+}
+
+local frame = CreateFrame("Frame")
+for e in pairs(eventHandlers) do
+	frame:RegisterEvent(e)
+end
+frame:SetScript("OnEvent", function(_, event) eventHandlers[event]() end)


### PR DESCRIPTION
## Summary
- hook `PLAYER_ENTERING_WORLD`, `BAG_UPDATE_DELAYED` and `BANKFRAME_CLOSED`
- scan all bags and bank containers
- store collected item links and counts per-character

## Testing
- `stylua EnhanceQoLAltInventory/AltInventory.lua`
- `luacheck EnhanceQoLAltInventory/AltInventory.lua`


------
https://chatgpt.com/codex/tasks/task_e_6870c9de9de88329a601ae9fc41f1fef