### PR TITLE
Add alt inventory viewer

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -4508,7 +4508,8 @@ function loadMain()
 	SLASH_ENHANCEQOL4 = "/eqol rag"
 	SLASH_ENHANCEQOL5 = "/eqol lag"
 	SLASH_ENHANCEQOL6 = "/eqol lcid"
-	SLASH_ENHANCEQOL6 = "/eqol rq"
+	SLASH_ENHANCEQOL7 = "/eqol rq"
+	SLASH_ENHANCEQOL8 = "/eqol altinv"
 	SlashCmdList["ENHANCEQOL"] = function(msg)
 		if msg == "resetframe" then
 			-- Frame zurücksetzen
@@ -4550,6 +4551,8 @@ function loadMain()
 			end
 		elseif msg == "rq" then
 			if addon.Query and addon.Query.frame then addon.Query.frame:Show() end
+		elseif msg == "altinv" then
+			if addon.AltInventory and addon.AltInventory.ToggleFrame then addon.AltInventory:ToggleFrame() end
 		else
 			if addon.aceFrame:IsShown() then
 				addon.aceFrame:Hide()
@@ -4705,9 +4708,9 @@ local eventHandlers = {
 			loadSubAddon("EnhanceQoLSound")
 			loadSubAddon("EnhanceQoLMouse")
 			loadSubAddon("EnhanceQoLMythicPlus")
-                        loadSubAddon("EnhanceQoLDrinkMacro")
-                        loadSubAddon("EnhanceQoLAltInventory")
-                        loadSubAddon("EnhanceQoLTooltip")
+			loadSubAddon("EnhanceQoLDrinkMacro")
+			loadSubAddon("EnhanceQoLAltInventory")
+			loadSubAddon("EnhanceQoLTooltip")
 			loadSubAddon("EnhanceQoLVendor")
 
 			checkBagIgnoreJunk()

--- a/EnhanceQoLAltInventory/AltInventory.lua
+++ b/EnhanceQoLAltInventory/AltInventory.lua
@@ -7,6 +7,7 @@ addon.AltInventory = AltInventory
 
 local function update()
 	if not addon.db.altInventory then addon.db.altInventory = {} end
+	if not addon.db.altInventoryNames then addon.db.altInventoryNames = {} end
 
 	local guid = UnitGUID("player")
 	if not guid then return end
@@ -37,6 +38,8 @@ local function update()
 	if IsReagentBankUnlocked() then scanBag(REAGENTBANK_CONTAINER) end
 
 	addon.db.altInventory[guid] = data
+	local name = GetUnitName("player", true)
+	addon.db.altInventoryNames[guid] = name
 end
 
 local eventHandlers = {

--- a/EnhanceQoLAltInventory/EnhanceQoLAltInventory.toc
+++ b/EnhanceQoLAltInventory/EnhanceQoLAltInventory.toc
@@ -12,3 +12,4 @@
 
 Init.lua
 AltInventory.lua
+UI.lua

--- a/EnhanceQoLAltInventory/UI.lua
+++ b/EnhanceQoLAltInventory/UI.lua
@@ -1,0 +1,112 @@
+-- luacheck: globals TooltipUtil
+local parentAddonName = "EnhanceQoL"
+local addonName, addon = ...
+if not addon then addon = _G[parentAddonName] end
+
+local AceGUI = LibStub("AceGUI-3.0")
+
+local AltInventory = addon.AltInventory or {}
+addon.AltInventory = AltInventory
+
+local frame
+local tabGroup
+
+local function getItemInfoFromLink(link)
+	if not link then return end
+	local tipData = C_TooltipInfo.GetHyperlink(link)
+	if not tipData then return end
+	TooltipUtil.SurfaceArgs(tipData)
+	return tipData.name, tipData.icon, tipData.quality
+end
+
+local function buildByItem(container)
+	local aggregated = {}
+	for guid, items in pairs(addon.db.altInventory or {}) do
+		for link, count in pairs(items) do
+			if not aggregated[link] then aggregated[link] = { total = 0, chars = {} } end
+			aggregated[link].total = aggregated[link].total + count
+			aggregated[link].chars[guid] = count
+		end
+	end
+
+	local tree = {}
+	for link, data in pairs(aggregated) do
+		local name, icon, quality = getItemInfoFromLink(link)
+		local colorHex = select(4, GetItemQualityColor(quality or 1))
+		local text = string.format("|T%s:0|t |c%s%s|r x%d", icon or "", colorHex, name or link, data.total)
+		local node = { value = link, text = text, children = {} }
+		for guid, count in pairs(data.chars) do
+			local charName = addon.db.altInventoryNames and addon.db.altInventoryNames[guid] or guid
+			table.insert(node.children, { value = link .. guid, text = string.format("%s x%d", charName, count) })
+		end
+		table.sort(node.children, function(a, b) return a.text < b.text end)
+		table.insert(tree, node)
+	end
+	table.sort(tree, function(a, b) return a.text < b.text end)
+
+	local tg = AceGUI:Create("TreeGroup")
+	tg:SetFullWidth(true)
+	tg:SetFullHeight(true)
+	tg:SetTree(tree)
+	container:AddChild(tg)
+end
+
+local function buildByChar(container)
+	local tree = {}
+	for guid, items in pairs(addon.db.altInventory or {}) do
+		local charName = addon.db.altInventoryNames and addon.db.altInventoryNames[guid] or guid
+		local node = { value = guid, text = charName, children = {} }
+		for link, count in pairs(items) do
+			local name, icon, quality = getItemInfoFromLink(link)
+			local colorHex = select(4, GetItemQualityColor(quality or 1))
+			local childText = string.format("|T%s:0|t |c%s%s|r x%d", icon or "", colorHex, name or link, count)
+			table.insert(node.children, { value = guid .. link, text = childText })
+		end
+		table.sort(node.children, function(a, b) return a.text < b.text end)
+		table.insert(tree, node)
+	end
+	table.sort(tree, function(a, b) return a.text < b.text end)
+
+	local tg = AceGUI:Create("TreeGroup")
+	tg:SetFullWidth(true)
+	tg:SetFullHeight(true)
+	tg:SetTree(tree)
+	container:AddChild(tg)
+end
+
+local function buildTab(container, group)
+	container:ReleaseChildren()
+	if group == "byitem" then
+		buildByItem(container)
+	else
+		buildByChar(container)
+	end
+end
+
+function AltInventory:CreateFrame()
+	if frame then return frame end
+	frame = AceGUI:Create("Frame")
+	frame:SetTitle("Alt Inventory")
+	frame:SetWidth(500)
+	frame:SetHeight(600)
+	frame:SetLayout("Fill")
+	frame.frame:Hide()
+
+	tabGroup = AceGUI:Create("TabGroup")
+	tabGroup:SetLayout("Fill")
+	tabGroup:SetTabs({ { text = "By Item", value = "byitem" }, { text = "By Character", value = "bychar" } })
+	tabGroup:SetCallback("OnGroupSelected", buildTab)
+	frame:AddChild(tabGroup)
+	tabGroup:SelectTab("byitem")
+	return frame
+end
+
+function AltInventory:ToggleFrame()
+	if not frame then self:CreateFrame() end
+	if frame.frame:IsShown() then
+		frame.frame:Hide()
+	else
+		frame.frame:Show()
+		buildTab(tabGroup, tabGroup:GetSelectedTab() or "byitem")
+	end
+end

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Every feature can be switched off; footprint is negligible.
 | Command          |Action                                           |
 | ---------------- |------------------------------------------------ |
 | <code>/eqol</code> |Open the configuration window                    |
-| <code>/eqol resetframe</code> |Re-center all Enhance QoL windows                |
-| <code>/eqol lag</code> |List gossip IDs of the current NPC dialog        |
+| <code>/eqol resetframe</code> |Re-center all Enhance QoL windows |
+| <code>/eqol lag</code> |List gossip IDs of the current NPC dialog |
 | <code>/eqol aag &lt;id&gt;</code> |Auto-pick a gossip option (chosen via <code>/eqol lag</code>) |
-| <code>/eqol rag &lt;id&gt;</code> |Remove an auto-picked gossip ID                  |
-
+| <code>/eqol rag &lt;id&gt;</code> |Remove an auto-picked gossip ID |
+| <code>/eqol altinv</code> |Toggle the alt-inventory viewer |
 ***
 
 ## Supported Languages


### PR DESCRIPTION
## Summary
- add names to alt inventory DB
- create viewer for alt inventory with AceGUI
- toggle via `/eqol altinv`
- document new command

## Testing
- `luacheck EnhanceQoLAltInventory/UI.lua EnhanceQoLAltInventory/AltInventory.lua EnhanceQoL/EnhanceQoL.lua`
- `stylua .`

------
https://chatgpt.com/codex/tasks/task_e_6870cbc7b5688329949fe2d255037ed1