### PR TITLE
Add localization scaffolding for AltInventory

### DIFF
--- a/EnhanceQoLAltInventory/EnhanceQoLAltInventory.toc
+++ b/EnhanceQoLAltInventory/EnhanceQoLAltInventory.toc
@@ -11,5 +11,6 @@
 ## Globe-Main: EnhanceQoL
 
 Init.lua
+locales.xml
 AltInventory.lua
 UI.lua

--- a/EnhanceQoLAltInventory/Locales/deDE.lua
+++ b/EnhanceQoLAltInventory/Locales/deDE.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "deDE")
+if not L then return end
+
+--@localization(locale="deDE", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/enUS.lua
+++ b/EnhanceQoLAltInventory/Locales/enUS.lua
@@ -1,0 +1,8 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "enUS", true)
+
+L["Alt Inventory"] = "Alt Inventory"
+L["By Item"] = "By Item"
+L["By Character"] = "By Character"
+L["Total"] = "Total"
+L["AltInventoryTooltip"] = "|cffeda55fClick|r to toggle Alt Inventory"
+

--- a/EnhanceQoLAltInventory/Locales/esES.lua
+++ b/EnhanceQoLAltInventory/Locales/esES.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "esES")
+if not L then return end
+
+--@localization(locale="esES", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/esMX.lua
+++ b/EnhanceQoLAltInventory/Locales/esMX.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "esMX")
+if not L then return end
+
+--@localization(locale="esMX", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/frFR.lua
+++ b/EnhanceQoLAltInventory/Locales/frFR.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "frFR")
+if not L then return end
+
+--@localization(locale="frFR", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/itIT.lua
+++ b/EnhanceQoLAltInventory/Locales/itIT.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "itIT")
+if not L then return end
+
+--@localization(locale="itIT", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/koKR.lua
+++ b/EnhanceQoLAltInventory/Locales/koKR.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "koKR")
+if not L then return end
+
+--@localization(locale="koKR", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/ptBR.lua
+++ b/EnhanceQoLAltInventory/Locales/ptBR.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "ptBR")
+if not L then return end
+
+--@localization(locale="ptBR", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/ruRU.lua
+++ b/EnhanceQoLAltInventory/Locales/ruRU.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "ruRU")
+if not L then return end
+
+--@localization(locale="ruRU", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/zhCN.lua
+++ b/EnhanceQoLAltInventory/Locales/zhCN.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "zhCN")
+if not L then return end
+
+--@localization(locale="zhCN", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/Locales/zhTW.lua
+++ b/EnhanceQoLAltInventory/Locales/zhTW.lua
@@ -1,0 +1,5 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_AltInventory", "zhTW")
+if not L then return end
+
+--@localization(locale="zhTW", namespace="AltInventory", format="lua_additive_table")@
+

--- a/EnhanceQoLAltInventory/locales.xml
+++ b/EnhanceQoLAltInventory/locales.xml
@@ -1,0 +1,16 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
+
+<Script file="Locales\\enUS.lua"/>
+<Script file="Locales\\deDE.lua"/>
+<Script file="Locales\\frFR.lua"/>
+<Script file="Locales\\esES.lua"/>
+<Script file="Locales\\esMX.lua"/>
+<Script file="Locales\\koKR.lua"/>
+<Script file="Locales\\zhCN.lua"/>
+<Script file="Locales\\zhTW.lua"/>
+<Script file="Locales\\ruRU.lua"/>
+<Script file="Locales\\ptBR.lua"/>
+<Script file="Locales\\itIT.lua"/>
+
+</Ui>
+


### PR DESCRIPTION
## Summary
- add locale skeleton files for AltInventory module
- register them in `locales.xml`
- load the locale file list from the TOC

## Testing
- `luacheck EnhanceQoLAltInventory/Locales/*.lua`
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_6870cf867b748329be417de5124cd398