### PR TITLE
Document alt inventory viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ English • German • French • Spanish • Italian • Russian • Korean •
 *   Hideable Bag Bar (mouse-over).
 *   Money tracker – total gold for all characters in one tooltip.
 *   Alt-inventory cache – counts how many of each item your alts own.
+*   Alt-inventory viewer – `/eqol altinv` shows which character holds each item. Counts are stored automatically when bags update.
 
 ### Character & Inspect
 


### PR DESCRIPTION
## Summary
- document `/eqol altinv` in Bags & Inventory section

## Testing
- `grep -n "Alt-inventory viewer" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_6870d071379883298ba202c57ddc4f81