### PR TITLE
Fix alt-inventory errors and add tooltip + search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.27.1] – 2025-07-11
+### ✨ Added
+- Search box for filtering the alt‑inventory viewer.
+### 🐛 Bug Fixes
+- Item tooltips now show when hovering entries in the alt‑inventory viewer.
+- Fixed an error when toggling the alt‑inventory viewer.
+
 ## [3.27.0] – 2025-07-11
 ### ✨ Added
 - **Teleport Favorites in the Compendium**

--- a/EnhanceQoLAltInventory/Locales/enUS.lua
+++ b/EnhanceQoLAltInventory/Locales/enUS.lua
@@ -5,4 +5,5 @@ L["By Item"] = "By Item"
 L["By Character"] = "By Character"
 L["Total"] = "Total"
 L["AltInventoryTooltip"] = "|cffeda55fClick|r to toggle Alt Inventory"
+L["Search"] = "Search"
 


### PR DESCRIPTION
## Summary
- show item tooltips when hovering entries in the Alt Inventory viewer
- add a search box to filter by item or character
- fix frame toggle error

## Testing
- `lua` and other required commands were not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6870e11e666c832987ce999cc26b084a