### PR TITLE
Fix vendor sell button anchor for no repair case

### DIFF
--- a/EnhanceQoLVendor/EnhanceQoLVendor.lua
+++ b/EnhanceQoLVendor/EnhanceQoLVendor.lua
@@ -170,8 +170,10 @@ local function createSellMoreButton()
 	sellMoreButton:SetSize(120, 25)
 	if MerchantRepairItemButton then
 		sellMoreButton:SetPoint("TOPLEFT", MerchantRepairItemButton, "BOTTOMLEFT", 5, -5)
+       elseif MerchantSellAllJunkButton then
+               sellMoreButton:SetPoint("TOPRIGHT", MerchantSellAllJunkButton, "BOTTOMLEFT", -5, -5)
 	else
-		sellMoreButton:SetPoint("BOTTOMLEFT", MerchantFrame, "BOTTOMLEFT", 60, 34)
+		sellMoreButton:SetPoint("BOTTOMLEFT", MerchantFrame, "BOTTOMLEFT", 60, 60)
 	end
 	sellMoreButton:SetText(L["vendorSellNext"])
 	sellMoreButton:SetScript("OnClick", function(self)


### PR DESCRIPTION
## Summary
- anchor vendor 'Sell next' button below and to the left of the junk button when repairs aren't available

## Testing
- `luacheck . --no-color -q`


------
https://chatgpt.com/codex/tasks/task_e_68712b85284083299e227d8aaf62ef4b