### PR TITLE
Add world marker cycling macro

### DIFF
--- a/EnhanceQoL/General/functions.lua
+++ b/EnhanceQoL/General/functions.lua
@@ -175,6 +175,15 @@ function addon.functions.createDropdownAce(text, list, order, callBack)
 	return dropdown
 end
 
+function addon.functions.createKeybindingAce(text, key, callBack)
+	local keybind = AceGUI:Create("Keybinding")
+	keybind:SetLabel(text or "")
+	if key then keybind:SetKey(key) end
+	keybind:SetFullWidth(true)
+	if callBack then keybind:SetCallback("OnKeyChanged", callBack) end
+	return keybind
+end
+
 function addon.functions.createWrapperData(data, container, L)
 	local sortedParents = {}
 	for _, checkbox in ipairs(data) do

--- a/EnhanceQoLMythicPlus/Bindings.lua
+++ b/EnhanceQoLMythicPlus/Bindings.lua
@@ -1,0 +1,6 @@
+BINDING_HEADER_ENHANCEQOL_MYTHICPLUS = "Enhance QoL - Mythic+"
+BINDING_NAME_ENHANCEQOL_WORLD_MARKER_CYCLE = "Cycle World Marker"
+
+function EnhanceQoL_WorldMarkerCycle()
+	if EnhanceQoL and EnhanceQoL.MythicPlus and EnhanceQoL.MythicPlus.functions then EnhanceQoL.MythicPlus.functions.cycleWorldMarker() end
+end

--- a/EnhanceQoLMythicPlus/EnhanceQoLMythicPlus.lua
+++ b/EnhanceQoLMythicPlus/EnhanceQoLMythicPlus.lua
@@ -355,6 +355,17 @@ local function checkRaidMarker()
 				SetRaidTarget(addon.MythicPlus.actTank, addon.db["autoMarkTankInDungeonMarker"])
 			end
 		end
+
+		function addon.MythicPlus.functions.cycleWorldMarker()
+			if not addon.db["worldMarkerCycleEnabled"] then return end
+			if IsShiftKeyDown() then
+				RunMacroText("/cwm 0")
+				addon.MythicPlus.variables.worldMarkerIndex = 0
+			else
+				addon.MythicPlus.variables.worldMarkerIndex = (addon.MythicPlus.variables.worldMarkerIndex % 8) + 1
+				RunMacroText("/wm [@cursor]" .. addon.MythicPlus.variables.worldMarkerIndex)
+			end
+		end
 	end
 
 	if addon.db["autoMarkHealerInDungeon"] then
@@ -1069,6 +1080,34 @@ local function addGroupFilterFrame(container)
 	end
 end
 
+local function addWorldMarkerFrame(container)
+	local wrapper = addon.functions.createContainer("SimpleGroup", "Flow")
+	container:AddChild(wrapper)
+
+	local groupCore = addon.functions.createContainer("InlineGroup", "List")
+	wrapper:AddChild(groupCore)
+
+	local cbEnable = addon.functions.createCheckboxAce(L["worldMarkerCycleEnabled"], addon.db["worldMarkerCycleEnabled"], function(self, _, value)
+		addon.db["worldMarkerCycleEnabled"] = value
+		container:ReleaseChildren()
+		addWorldMarkerFrame(container)
+	end)
+	groupCore:AddChild(cbEnable)
+
+	if addon.db["worldMarkerCycleEnabled"] then
+		groupCore:AddChild(addon.functions.createSpacerAce())
+		local keybind = addon.functions.createKeybindingAce(L["worldMarkerCycleKeybind"], GetBindingKey("ENHANCEQOL_WORLD_MARKER_CYCLE"), function(self, _, key)
+			if key and key ~= "" then
+				SetBinding(key, "ENHANCEQOL_WORLD_MARKER_CYCLE")
+			else
+				SetBinding(nil, "ENHANCEQOL_WORLD_MARKER_CYCLE")
+			end
+			SaveBindings(GetCurrentBindingSet())
+		end)
+		groupCore:AddChild(keybind)
+	end
+end
+
 local function addRatingFrame(container)
 	local wrapper = addon.functions.createContainer("SimpleGroup", "Flow")
 	container:AddChild(wrapper)
@@ -1239,6 +1278,7 @@ addon.functions.addToTree(nil, {
 		{ value = "brtracker", text = L["BRTracker"] },
 		{ value = "rating", text = DUNGEON_SCORE },
 		{ value = "talents", text = L["TalentReminder"] },
+		{ value = "worldmarker", text = L["WorldMarkerCycle"] },
 		{ value = "objectivetracker", text = HUD_EDIT_MODE_OBJECTIVE_TRACKER_LABEL },
 		{ value = "groupfilter", text = L["groupFilter"] },
 	},
@@ -1261,6 +1301,8 @@ function addon.MythicPlus.functions.treeCallback(container, group)
 		addRatingFrame(container)
 	elseif group == "mythicplus\001talents" then
 		addTalentFrame(container)
+	elseif group == "mythicplus\001worldmarker" then
+		addWorldMarkerFrame(container)
 	elseif group == "mythicplus\001groupfilter" then
 		addGroupFilterFrame(container)
 	elseif group == "mythicplus\001objectivetracker" then

--- a/EnhanceQoLMythicPlus/EnhanceQoLMythicPlus.toc
+++ b/EnhanceQoLMythicPlus/EnhanceQoLMythicPlus.toc
@@ -31,3 +31,4 @@ TalentReminder.lua
 DungeonFilter.lua
 ObjectiveTracker.lua
 EnhanceQoLMythicPlus.lua
+Bindings.lua

--- a/EnhanceQoLMythicPlus/Init.lua
+++ b/EnhanceQoLMythicPlus/Init.lua
@@ -50,6 +50,7 @@ addon.functions.InitDBValue("mythicPlusIgnoreMythic", true)
 addon.functions.InitDBValue("mythicPlusIgnoreHeroic", true)
 addon.functions.InitDBValue("mythicPlusIgnoreNormal", true)
 addon.functions.InitDBValue("mythicPlusIgnoreTimewalking", true)
+addon.functions.InitDBValue("worldMarkerCycleEnabled", false)
 
 -- BR Tracker
 addon.functions.InitDBValue("mythicPlusBRTrackerEnabled", false)
@@ -69,6 +70,7 @@ addon.MythicPlus.functions = {}
 addon.MythicPlus.Buttons = {}
 addon.MythicPlus.nrOfButtons = 0
 addon.MythicPlus.variables = {}
+addon.MythicPlus.variables.worldMarkerIndex = 0
 
 -- Teleports
 addon.functions.InitDBValue("teleportFrame", false)

--- a/EnhanceQoLMythicPlus/Init.lua
+++ b/EnhanceQoLMythicPlus/Init.lua
@@ -70,7 +70,6 @@ addon.MythicPlus.functions = {}
 addon.MythicPlus.Buttons = {}
 addon.MythicPlus.nrOfButtons = 0
 addon.MythicPlus.variables = {}
-addon.MythicPlus.variables.worldMarkerIndex = 0
 
 -- Teleports
 addon.functions.InitDBValue("teleportFrame", false)

--- a/EnhanceQoLMythicPlus/Locales/enUS.lua
+++ b/EnhanceQoLMythicPlus/Locales/enUS.lua
@@ -97,6 +97,10 @@ L["mythicPlusBRTrackerEnabled"] = "Enable Combat Resurrection tracker"
 L["mythicPlusBRTrackerLocked"] = "Lock the tracker's position"
 L["mythicPlusBRButtonSizeHeadline"] = "Button Size"
 
+L["WorldMarkerCycle"] = "World Marker Cycle"
+L["worldMarkerCycleEnabled"] = "Enable world marker cycling"
+L["worldMarkerCycleKeybind"] = "Keybind"
+
 -- Talent Reminder
 L["TalentReminder"] = "Talent Reminder"
 L["talentReminderEnabled"] = "Enable Talent Reminder"


### PR DESCRIPTION
## Summary
- create `createKeybindingAce` helper
- enable world marker cycling with a new keybind
- add translations for the new feature

## Testing
- `stylua EnhanceQoL/General/functions.lua EnhanceQoLMythicPlus/EnhanceQoLMythicPlus.lua EnhanceQoLMythicPlus/Init.lua EnhanceQoLMythicPlus/Locales/enUS.lua EnhanceQoLMythicPlus/Bindings.lua`

------
https://chatgpt.com/codex/tasks/task_e_687164839cc48329bc3a94da802612b9