### PR TITLE
Add draggable tree for aura tracker

### DIFF
--- a/EnhanceQoL/widgets/DragTreeGroup.lua
+++ b/EnhanceQoL/widgets/DragTreeGroup.lua
@@ -1,4 +1,5 @@
 local AceGUI = LibStub("AceGUI-3.0")
+local GetMouseFocus = _G.GetMouseFocus
 
 --[[ DragTreeGroup - simple TreeGroup extension with drag-and-drop
      Dragging is started with a left-click while holding ALT.
@@ -6,7 +7,7 @@ local AceGUI = LibStub("AceGUI-3.0")
      an "OnDragDrop" callback with the source and target unique values.
 ]]
 
-local Type, Version = "EQOL_DragTreeGroup", 2
+local Type, Version = "EQOL_DragTreeGroup", 3
 
 local function Constructor()
 	local tree = AceGUI:Create("TreeGroup")

--- a/EnhanceQoL/widgets/DragTreeGroup.lua
+++ b/EnhanceQoL/widgets/DragTreeGroup.lua
@@ -1,0 +1,45 @@
+local AceGUI = LibStub("AceGUI-3.0")
+
+--[[ DragTreeGroup - simple TreeGroup extension with drag-and-drop
+     Dragging is started with a left-click while holding ALT.
+     When the mouse is released over another entry, the widget fires
+     an "OnDragDrop" callback with the source and target unique values.
+]]
+
+local Type, Version = "EQOL_DragTreeGroup", 1
+
+local function Constructor()
+	local tree = AceGUI:Create("TreeGroup")
+	tree.type = Type
+
+	if not tree.origCreateButton then tree.origCreateButton = tree.CreateButton end
+
+	function tree:CreateButton()
+		local btn = self:origCreateButton()
+		local oldClick = btn:GetScript("OnClick")
+		btn:SetScript("OnMouseDown", function(frame, button)
+			if button == "LeftButton" and IsAltKeyDown() then
+				frame.obj.dragSource = frame.uniquevalue
+				frame.obj.dragging = true
+			else
+				if oldClick then oldClick(frame, button) end
+			end
+		end)
+		btn:SetScript("OnMouseUp", function(frame, button)
+			local obj = frame.obj
+			if obj.dragging then
+				obj.dragging = nil
+				local src = obj.dragSource
+				obj.dragSource = nil
+				if src and frame.uniquevalue then obj:Fire("OnDragDrop", src, frame.uniquevalue) end
+			else
+				if oldClick then oldClick(frame, button) end
+			end
+		end)
+		return btn
+	end
+
+	return tree
+end
+
+AceGUI:RegisterWidgetType(Type, Constructor, Version)

--- a/EnhanceQoL/widgets/DragTreeGroup.lua
+++ b/EnhanceQoL/widgets/DragTreeGroup.lua
@@ -6,7 +6,7 @@ local AceGUI = LibStub("AceGUI-3.0")
      an "OnDragDrop" callback with the source and target unique values.
 ]]
 
-local Type, Version = "EQOL_DragTreeGroup", 1
+local Type, Version = "EQOL_DragTreeGroup", 2
 
 local function Constructor()
 	local tree = AceGUI:Create("TreeGroup")
@@ -14,30 +14,61 @@ local function Constructor()
 
 	if not tree.origCreateButton then tree.origCreateButton = tree.CreateButton end
 
-	function tree:CreateButton()
-		local btn = self:origCreateButton()
-		local oldClick = btn:GetScript("OnClick")
-		btn:SetScript("OnMouseDown", function(frame, button)
-			if button == "LeftButton" and IsAltKeyDown() then
-				frame.obj.dragSource = frame.uniquevalue
-				frame.obj.dragging = true
-			else
-				if oldClick then oldClick(frame, button) end
-			end
-		end)
-		btn:SetScript("OnMouseUp", function(frame, button)
-			local obj = frame.obj
-			if obj.dragging then
-				obj.dragging = nil
-				local src = obj.dragSource
-				obj.dragSource = nil
-				if src and frame.uniquevalue then obj:Fire("OnDragDrop", src, frame.uniquevalue) end
-			else
-				if oldClick then oldClick(frame, button) end
-			end
-		end)
-		return btn
-	end
+        function tree:CreateButton()
+                local btn = self:origCreateButton()
+
+                local oldMouseDown = btn:GetScript("OnMouseDown")
+                local oldMouseUp = btn:GetScript("OnMouseUp")
+                local oldEnter = btn:GetScript("OnEnter")
+                local oldLeave = btn:GetScript("OnLeave")
+
+                btn:SetScript("OnMouseDown", function(frame, button)
+                        if button == "LeftButton" and IsAltKeyDown() then
+                                frame.obj.dragSource = frame.uniquevalue
+                                frame.obj.dragging = true
+                                frame.obj.dragButton = frame
+                                frame:LockHighlight()
+                        elseif oldMouseDown then
+                                oldMouseDown(frame, button)
+                        end
+                end)
+
+                local function findTarget(obj)
+                        local focus = GetMouseFocus()
+                        while focus do
+                                if focus.obj == obj and focus.uniquevalue then return focus.uniquevalue end
+                                focus = focus:GetParent()
+                        end
+                end
+
+                btn:SetScript("OnMouseUp", function(frame, button)
+                        local obj = frame.obj
+                        if obj.dragging then
+                                obj.dragging = nil
+                                if obj.dragButton then
+                                        obj.dragButton:UnlockHighlight()
+                                        obj.dragButton = nil
+                                end
+                                local src = obj.dragSource
+                                obj.dragSource = nil
+                                local target = findTarget(obj)
+                                if src and target and src ~= target then obj:Fire("OnDragDrop", src, target) end
+                        end
+                        if oldMouseUp then oldMouseUp(frame, button) end
+                end)
+
+                btn:SetScript("OnEnter", function(frame)
+                        if frame.obj.dragging then frame:LockHighlight() end
+                        if oldEnter then oldEnter(frame) end
+                end)
+
+                btn:SetScript("OnLeave", function(frame)
+                        if frame.obj.dragging and not frame.selected then frame:UnlockHighlight() end
+                        if oldLeave then oldLeave(frame) end
+                end)
+
+                return btn
+        end
 
 	return tree
 end

--- a/EnhanceQoL/widgets/DragTreeGroup.lua
+++ b/EnhanceQoL/widgets/DragTreeGroup.lua
@@ -1,5 +1,5 @@
 local AceGUI = LibStub("AceGUI-3.0")
-local GetMouseFocus = _G.GetMouseFocus
+local GetMouseFocus = _G.GetMouseFoci
 
 --[[ DragTreeGroup - simple TreeGroup extension with drag-and-drop
      Dragging is started with a left-click while holding ALT.
@@ -15,61 +15,58 @@ local function Constructor()
 
 	if not tree.origCreateButton then tree.origCreateButton = tree.CreateButton end
 
-        function tree:CreateButton()
-                local btn = self:origCreateButton()
+	function tree:CreateButton()
+		local btn = self:origCreateButton()
 
-                local oldMouseDown = btn:GetScript("OnMouseDown")
-                local oldMouseUp = btn:GetScript("OnMouseUp")
-                local oldEnter = btn:GetScript("OnEnter")
-                local oldLeave = btn:GetScript("OnLeave")
+		local oldMouseDown = btn:GetScript("OnMouseDown")
+		local oldMouseUp = btn:GetScript("OnMouseUp")
+		local oldEnter = btn:GetScript("OnEnter")
+		local oldLeave = btn:GetScript("OnLeave")
 
-                btn:SetScript("OnMouseDown", function(frame, button)
-                        if button == "LeftButton" and IsAltKeyDown() then
-                                frame.obj.dragSource = frame.uniquevalue
-                                frame.obj.dragging = true
-                                frame.obj.dragButton = frame
-                                frame:LockHighlight()
-                        elseif oldMouseDown then
-                                oldMouseDown(frame, button)
-                        end
-                end)
+		btn:SetScript("OnMouseDown", function(frame, button)
+			if button == "LeftButton" and IsAltKeyDown() then
+				frame.obj.dragSource = frame.uniquevalue
+				frame.obj.dragging = true
+				frame.obj.dragButton = frame
+				frame:LockHighlight()
+			elseif oldMouseDown then
+				oldMouseDown(frame, button)
+			end
+		end)
 
-                local function findTarget(obj)
-                        local focus = GetMouseFocus()
-                        while focus do
-                                if focus.obj == obj and focus.uniquevalue then return focus.uniquevalue end
-                                focus = focus:GetParent()
-                        end
-                end
+		local function findTarget(obj)
+			local focus = GetMouseFocus()
+			if focus and focus[1] and focus[1].obj == obj and focus[1].uniquevalue then return focus[1].uniquevalue end
+		end
 
-                btn:SetScript("OnMouseUp", function(frame, button)
-                        local obj = frame.obj
-                        if obj.dragging then
-                                obj.dragging = nil
-                                if obj.dragButton then
-                                        obj.dragButton:UnlockHighlight()
-                                        obj.dragButton = nil
-                                end
-                                local src = obj.dragSource
-                                obj.dragSource = nil
-                                local target = findTarget(obj)
-                                if src and target and src ~= target then obj:Fire("OnDragDrop", src, target) end
-                        end
-                        if oldMouseUp then oldMouseUp(frame, button) end
-                end)
+		btn:SetScript("OnMouseUp", function(frame, button)
+			local obj = frame.obj
+			if obj.dragging then
+				obj.dragging = nil
+				if obj.dragButton then
+					obj.dragButton:UnlockHighlight()
+					obj.dragButton = nil
+				end
+				local src = obj.dragSource
+				obj.dragSource = nil
+				local target = findTarget(obj)
+				if src and target and src ~= target then obj:Fire("OnDragDrop", src, target) end
+			end
+			if oldMouseUp then oldMouseUp(frame, button) end
+		end)
 
-                btn:SetScript("OnEnter", function(frame)
-                        if frame.obj.dragging then frame:LockHighlight() end
-                        if oldEnter then oldEnter(frame) end
-                end)
+		btn:SetScript("OnEnter", function(frame)
+			if frame.obj.dragging then frame:LockHighlight() end
+			if oldEnter then oldEnter(frame) end
+		end)
 
-                btn:SetScript("OnLeave", function(frame)
-                        if frame.obj.dragging and not frame.selected then frame:UnlockHighlight() end
-                        if oldLeave then oldLeave(frame) end
-                end)
+		btn:SetScript("OnLeave", function(frame)
+			if frame.obj.dragging and not frame.selected then frame:UnlockHighlight() end
+			if oldLeave then oldLeave(frame) end
+		end)
 
-                return btn
-        end
+		return btn
+	end
 
 	return tree
 end

--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -491,6 +491,49 @@ local function refreshTree(selectValue)
 	if selectValue then treeGroup:SelectByValue(selectValue) end
 end
 
+local function handleDragDrop(src, dst)
+	if not src or not dst then return end
+
+	local sCat, _, sBuff = strsplit("\001", src)
+	local dCat, _, dBuff = strsplit("\001", dst)
+	sCat = tonumber(sCat)
+	dCat = tonumber(dCat)
+	if not sBuff then return end
+	sBuff = tonumber(sBuff)
+	if dBuff then dBuff = tonumber(dBuff) end
+
+	local srcCat = addon.db["buffTrackerCategories"][sCat]
+	local dstCat = addon.db["buffTrackerCategories"][dCat]
+	if not srcCat or not dstCat then return end
+
+	local buffData = srcCat.buffs[sBuff]
+	if not buffData then return end
+
+	srcCat.buffs[sBuff] = nil
+	addon.db["buffTrackerOrder"][sCat] = addon.db["buffTrackerOrder"][sCat] or {}
+	for i, v in ipairs(addon.db["buffTrackerOrder"][sCat]) do
+		if v == sBuff then
+			table.remove(addon.db["buffTrackerOrder"][sCat], i)
+			break
+		end
+	end
+
+	dstCat.buffs[sBuff] = buffData
+	addon.db["buffTrackerOrder"][dCat] = addon.db["buffTrackerOrder"][dCat] or {}
+	local insertPos = #addon.db["buffTrackerOrder"][dCat] + 1
+	if dBuff then
+		for i, v in ipairs(addon.db["buffTrackerOrder"][dCat]) do
+			if v == dBuff then
+				insertPos = i
+				break
+			end
+		end
+	end
+	table.insert(addon.db["buffTrackerOrder"][dCat], insertPos, sBuff)
+
+	refreshTree(selectedCategory)
+end
+
 function addon.Aura.functions.buildCategoryOptions(container, catId)
 	local cat = getCategory(catId)
 	if not cat then return end
@@ -769,7 +812,7 @@ function addon.Aura.functions.addBuffTrackerOptions(container)
 	left:SetFullHeight(true)
 	wrapper:AddChild(left)
 
-	treeGroup = AceGUI:Create("TreeGroup")
+	treeGroup = AceGUI:Create("EQOL_DragTreeGroup")
 	treeGroup:SetFullHeight(true)
 	treeGroup:SetFullWidth(true)
 	treeGroup:SetTree(getCategoryTree())
@@ -813,6 +856,7 @@ function addon.Aura.functions.addBuffTrackerOptions(container)
 			addon.Aura.functions.buildCategoryOptions(scroll, catId)
 		end
 	end)
+	treeGroup:SetCallback("OnDragDrop", function(_, _, src, dst) handleDragDrop(src, dst) end)
 	left:AddChild(treeGroup)
 
 	local ok = treeGroup:SelectByValue(tostring(selectedCategory))

--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -529,9 +529,10 @@ local function handleDragDrop(src, dst)
 			end
 		end
 	end
-	table.insert(addon.db["buffTrackerOrder"][dCat], insertPos, sBuff)
+        table.insert(addon.db["buffTrackerOrder"][dCat], insertPos, sBuff)
 
-	refreshTree(selectedCategory)
+        refreshTree(selectedCategory)
+        scanBuffs()
 end
 
 function addon.Aura.functions.buildCategoryOptions(container, catId)

--- a/EnhanceQoLAura/EnhanceQoLAura.toc
+++ b/EnhanceQoLAura/EnhanceQoLAura.toc
@@ -12,6 +12,7 @@
 
 Init.lua
 locales.xml
+..\EnhanceQoL\widgets\DragTreeGroup.lua
 
 #DetailsSkin.lua
 EnhanceQoLAura.lua


### PR DESCRIPTION
## Summary
- add custom `EQOL_DragTreeGroup` widget enabling drag-and-drop
- integrate drag support into BuffTracker UI
- update Aura TOC to load new widget

## Testing
- `luacheck EnhanceQoL/widgets/DragTreeGroup.lua EnhanceQoLAura/BuffTracker.lua` (passes)
- `luacheck .` (passes)

------
https://chatgpt.com/codex/tasks/task_e_6873e354e344832992c1ed4ab7ef10c5