### PR TITLE
Add per-buff visibility options

### DIFF
--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -13,9 +13,12 @@ local AceGUI = addon.AceGUI
 local selectedCategory = addon.db["buffTrackerSelectedCategory"] or 1
 
 for _, cat in pairs(addon.db["buffTrackerCategories"]) do
-	if not cat.trackType then cat.trackType = "BUFF" end
-	if not cat.allowedSpecs then cat.allowedSpecs = {} end
-	if not cat.allowedClasses then cat.allowedClasses = {} end
+        for _, buff in pairs(cat.buffs or {}) do
+                if not buff.trackType then buff.trackType = "BUFF" end
+                if not buff.allowedSpecs then buff.allowedSpecs = {} end
+                if not buff.allowedClasses then buff.allowedClasses = {} end
+                if not buff.allowedRoles then buff.allowedRoles = {} end
+        end
 end
 
 local anchors = {}
@@ -70,6 +73,24 @@ local function categoryAllowed(cat)
 		if not role or not cat.allowedRoles[role] then return false end
 	end
 	return true
+end
+
+local function buffAllowed(buff)
+        if buff.allowedClasses and next(buff.allowedClasses) then
+                if not buff.allowedClasses[addon.variables.unitClass] then return false end
+        end
+        if buff.allowedSpecs and next(buff.allowedSpecs) then
+                local specIndex = addon.variables.unitSpec
+                if not specIndex then return false end
+                local currentSpecID = GetSpecializationInfo(specIndex)
+                if not buff.allowedSpecs[currentSpecID] then return false end
+        end
+        if buff.allowedRoles and next(buff.allowedRoles) then
+                local role = UnitGroupRolesAssigned("player")
+                if role == "NONE" then role = addon.variables.unitRole end
+                if not role or not buff.allowedRoles[role] then return false end
+        end
+        return true
 end
 
 function addon.Aura.functions.BuildSoundTable()
@@ -239,9 +260,16 @@ local function playBuffSound(catId, baseId, altId)
 end
 
 local function updateBuff(catId, id)
-	local cat = getCategory(catId)
-	local buff = cat and cat.buffs and cat.buffs[id]
-	local aura = C_UnitAuras.GetPlayerAuraBySpellID(id)
+        local cat = getCategory(catId)
+        local buff = cat and cat.buffs and cat.buffs[id]
+        if buff and not buffAllowed(buff) then
+                if activeBuffFrames[catId] and activeBuffFrames[catId][id] then
+                        activeBuffFrames[catId][id]:Hide()
+                end
+                return
+        end
+
+        local aura = C_UnitAuras.GetPlayerAuraBySpellID(id)
 	local triggeredId = id
 	if not aura and buff and buff.altIDs then
 		for _, altId in ipairs(buff.altIDs) do
@@ -252,13 +280,14 @@ local function updateBuff(catId, id)
 			end
 		end
 	end
-	if aura then
-		if cat and cat.trackType == "DEBUFF" and not aura.isHarmful then
-			aura = nil
-		elseif cat and cat.trackType == "BUFF" and not aura.isHelpful then
-			aura = nil
-		end
-	end
+        if aura then
+                local tType = buff and buff.trackType or (cat and cat.trackType) or "BUFF"
+                if tType == "DEBUFF" and not aura.isHarmful then
+                        aura = nil
+                elseif tType == "BUFF" and not aura.isHelpful then
+                        aura = nil
+                end
+        end
 
 	activeBuffFrames[catId] = activeBuffFrames[catId] or {}
 	local frame = activeBuffFrames[catId][id]
@@ -419,7 +448,19 @@ local function addBuff(catId, id)
 	local cat = getCategory(catId)
 	if not cat then return end
 
-	cat.buffs[id] = { name = spellData.name, icon = spellData.iconID, altIDs = {}, showWhenMissing = false, showAlways = false, glow = false, castOnClick = false }
+        cat.buffs[id] = {
+                name = spellData.name,
+                icon = spellData.iconID,
+                altIDs = {},
+                showWhenMissing = false,
+                showAlways = false,
+                glow = false,
+                castOnClick = false,
+                trackType = "BUFF",
+                allowedSpecs = {},
+                allowedClasses = {},
+                allowedRoles = {},
+        }
 
 	if nil == addon.db["buffTrackerOrder"][catId] then addon.db["buffTrackerOrder"][catId] = {} end
 	if not tContains(addon.db["buffTrackerOrder"][catId], id) then table.insert(addon.db["buffTrackerOrder"][catId], id) end
@@ -454,8 +495,12 @@ local treeGroup
 
 local function getCategoryTree()
 	local tree = {}
-	for catId, cat in pairs(addon.db["buffTrackerCategories"]) do
-		local node = { value = catId, text = cat.name, children = {} }
+        for catId, cat in pairs(addon.db["buffTrackerCategories"]) do
+                local text = cat.name
+                if addon.db["buffTrackerEnabled"] and addon.db["buffTrackerEnabled"][catId] == false then
+                        text = "|cff808080" .. text .. "|r"
+                end
+                local node = { value = catId, text = text, children = {} }
 		local buffs = {}
 		for id, data in pairs(cat.buffs) do
 			table.insert(buffs, { id = id, name = data.name })
@@ -581,54 +626,6 @@ function addon.Aura.functions.buildCategoryOptions(container, catId)
 	dirDrop:SetRelativeWidth(0.4)
 	core:AddChild(dirDrop)
 
-	local typeDrop = addon.functions.createDropdownAce(L["TrackType"], { BUFF = L["Buff"], DEBUFF = L["Debuff"] }, nil, function(self, _, val)
-		cat.trackType = val
-		if activeBuffFrames[catId] then
-			for _, frame in pairs(activeBuffFrames[catId]) do
-				frame:Hide()
-			end
-		end
-		scanBuffs()
-	end)
-	typeDrop:SetValue(cat.trackType or "BUFF")
-	typeDrop:SetRelativeWidth(0.4)
-	core:AddChild(typeDrop)
-
-	local specDrop = addon.functions.createDropdownAce(L["ShowForSpec"], specNames, nil, function(self, event, key, checked)
-		cat.allowedSpecs = cat.allowedSpecs or {}
-		cat.allowedSpecs[key] = checked or nil
-		scanBuffs()
-	end)
-	specDrop:SetMultiselect(true)
-	for specID, val in pairs(cat.allowedSpecs or {}) do
-		if val then specDrop:SetItemValue(specID, true) end
-	end
-	specDrop:SetRelativeWidth(0.48)
-	core:AddChild(specDrop)
-
-	local classDrop = addon.functions.createDropdownAce(L["ShowForClass"], classNames, nil, function(self, event, key, checked)
-		cat.allowedClasses = cat.allowedClasses or {}
-		cat.allowedClasses[key] = checked or nil
-		scanBuffs()
-	end)
-	classDrop:SetMultiselect(true)
-	for c, val in pairs(cat.allowedClasses or {}) do
-		if val then classDrop:SetItemValue(c, true) end
-	end
-	classDrop:SetRelativeWidth(0.48)
-	core:AddChild(classDrop)
-
-	local roleDrop = addon.functions.createDropdownAce(L["ShowForRole"], roleNames, nil, function(self, event, key, checked)
-		cat.allowedRoles = cat.allowedRoles or {}
-		cat.allowedRoles[key] = checked or nil
-		scanBuffs()
-	end)
-	roleDrop:SetMultiselect(true)
-	for r, val in pairs(cat.allowedRoles or {}) do
-		if val then roleDrop:SetItemValue(r, true) end
-	end
-	roleDrop:SetRelativeWidth(0.5)
-	core:AddChild(roleDrop)
 
 	local spellEdit = addon.functions.createEditboxAce(L["AddSpellID"], nil, function(self, _, text)
 		local id = tonumber(text)
@@ -740,7 +737,51 @@ function addon.Aura.functions.buildBuffOptions(container, catId, buffId)
 		buff.glow = val
 		scanBuffs()
 	end)
-	wrapper:AddChild(cbGlow)
+        wrapper:AddChild(cbGlow)
+
+        local typeDrop = addon.functions.createDropdownAce(L["TrackType"], { BUFF = L["Buff"], DEBUFF = L["Debuff"] }, nil, function(self, _, val)
+                buff.trackType = val
+                scanBuffs()
+        end)
+        typeDrop:SetValue(buff.trackType or "BUFF")
+        typeDrop:SetRelativeWidth(0.4)
+        wrapper:AddChild(typeDrop)
+
+        local specDrop = addon.functions.createDropdownAce(L["ShowForSpec"], specNames, nil, function(self, event, key, checked)
+                buff.allowedSpecs = buff.allowedSpecs or {}
+                buff.allowedSpecs[key] = checked or nil
+                scanBuffs()
+        end)
+        specDrop:SetMultiselect(true)
+        for specID, val in pairs(buff.allowedSpecs or {}) do
+                if val then specDrop:SetItemValue(specID, true) end
+        end
+        specDrop:SetRelativeWidth(0.48)
+        wrapper:AddChild(specDrop)
+
+        local classDrop = addon.functions.createDropdownAce(L["ShowForClass"], classNames, nil, function(self, event, key, checked)
+                buff.allowedClasses = buff.allowedClasses or {}
+                buff.allowedClasses[key] = checked or nil
+                scanBuffs()
+        end)
+        classDrop:SetMultiselect(true)
+        for c, val in pairs(buff.allowedClasses or {}) do
+                if val then classDrop:SetItemValue(c, true) end
+        end
+        classDrop:SetRelativeWidth(0.48)
+        wrapper:AddChild(classDrop)
+
+        local roleDrop = addon.functions.createDropdownAce(L["ShowForRole"], roleNames, nil, function(self, event, key, checked)
+                buff.allowedRoles = buff.allowedRoles or {}
+                buff.allowedRoles[key] = checked or nil
+                scanBuffs()
+        end)
+        roleDrop:SetMultiselect(true)
+        for r, val in pairs(buff.allowedRoles or {}) do
+                if val then roleDrop:SetItemValue(r, true) end
+        end
+        roleDrop:SetRelativeWidth(0.5)
+        wrapper:AddChild(roleDrop)
 
 	-- if IsSpellKnown(buffId) or IsSpellKnownOrOverridesKnown(buffId) then
 	-- 	local cbCast = addon.functions.createCheckboxAce(L["buffTrackerCastOnClick"], buff.castOnClick, function(_, _, val)
@@ -828,14 +869,10 @@ function addon.Aura.functions.addBuffTrackerOptions(container)
 				point = "CENTER",
 				x = 0,
 				y = 0,
-				size = 36,
-				direction = "RIGHT",
-				trackType = "BUFF",
-				allowedSpecs = {},
-				allowedClasses = {},
-				allowedRoles = {},
-				buffs = {},
-			}
+                                size = 36,
+                                direction = "RIGHT",
+                                buffs = {},
+                        }
 			ensureAnchor(newId)
 			refreshTree(newId) -- rebuild tree and select new node
 			return -- don’t build options for pseudo‑node

--- a/EnhanceQoLAura/Init.lua
+++ b/EnhanceQoLAura/Init.lua
@@ -26,13 +26,9 @@ addon.functions.InitDBValue("buffTrackerCategories", {
 		x = 0,
 		y = 0,
 		size = 36,
-		direction = "RIGHT",
-		trackType = "BUFF",
-		allowedSpecs = {},
-		allowedClasses = {},
-		allowedRoles = {},
-		buffs = {},
-	},
+                direction = "RIGHT",
+                buffs = {},
+        },
 })
 addon.functions.InitDBValue("buffTrackerEnabled", {})
 addon.functions.InitDBValue("buffTrackerLocked", {})
@@ -45,14 +41,14 @@ addon.functions.InitDBValue("buffTrackerSoundsEnabled", {})
 if type(addon.db["buffTrackerSelectedCategory"]) ~= "number" then addon.db["buffTrackerSelectedCategory"] = 1 end
 
 for _, cat in pairs(addon.db["buffTrackerCategories"]) do
-	if not cat.trackType then cat.trackType = "BUFF" end
-	if not cat.allowedSpecs then cat.allowedSpecs = {} end
-	if not cat.allowedClasses then cat.allowedClasses = {} end
-	if not cat.allowedRoles then cat.allowedRoles = {} end
-	for _, buff in pairs(cat.buffs or {}) do
-		if not buff.altIDs then buff.altIDs = {} end
-		if buff.showWhenMissing == nil then buff.showWhenMissing = false end
-		if buff.showAlways == nil then buff.showAlways = false end
-		if buff.glow == nil then buff.glow = false end
-	end
+        for _, buff in pairs(cat.buffs or {}) do
+                if not buff.altIDs then buff.altIDs = {} end
+                if buff.showWhenMissing == nil then buff.showWhenMissing = false end
+                if buff.showAlways == nil then buff.showAlways = false end
+                if buff.glow == nil then buff.glow = false end
+                if not buff.trackType then buff.trackType = "BUFF" end
+                if not buff.allowedSpecs then buff.allowedSpecs = {} end
+                if not buff.allowedClasses then buff.allowedClasses = {} end
+                if not buff.allowedRoles then buff.allowedRoles = {} end
+        end
 end


### PR DESCRIPTION
## Summary
- move spec/class/role and aura type settings from categories to individual auras
- colour disabled categories grey in the tracker tree

## Testing
- `stylua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687409ccd85c832992c2ffe68339308b