### PR TITLE
Add per-aura stack/timer options

### DIFF
--- a/EnhanceQoLAura/Init.lua
+++ b/EnhanceQoLAura/Init.lua
@@ -43,16 +43,24 @@ addon.functions.InitDBValue("buffTrackerShowTimerText", true)
 if type(addon.db["buffTrackerSelectedCategory"]) ~= "number" then addon.db["buffTrackerSelectedCategory"] = 1 end
 
 for _, cat in pairs(addon.db["buffTrackerCategories"]) do
-        for _, buff in pairs(cat.buffs or {}) do
-                if not buff.altIDs then buff.altIDs = {} end
-                if buff.showWhenMissing == nil then buff.showWhenMissing = false end
-                if buff.showAlways == nil then buff.showAlways = false end
-                if buff.glow == nil then buff.glow = false end
-                if not buff.trackType then buff.trackType = "BUFF" end
-                if buff.stackOp == nil then buff.stackOp = nil end
-                if buff.stackVal == nil then buff.stackVal = nil end
-                if not buff.allowedSpecs then buff.allowedSpecs = {} end
-                if not buff.allowedClasses then buff.allowedClasses = {} end
-                if not buff.allowedRoles then buff.allowedRoles = {} end
-        end
+	for _, buff in pairs(cat.buffs or {}) do
+		if not buff.altIDs then buff.altIDs = {} end
+		if buff.showWhenMissing == nil then buff.showWhenMissing = false end
+		if buff.showAlways == nil then buff.showAlways = false end
+		if buff.glow == nil then buff.glow = false end
+		if not buff.trackType then buff.trackType = "BUFF" end
+		if buff.stackOp == nil then buff.stackOp = nil end
+		if buff.stackVal == nil then buff.stackVal = nil end
+		if not buff.allowedSpecs then buff.allowedSpecs = {} end
+		if not buff.allowedClasses then buff.allowedClasses = {} end
+		if not buff.allowedRoles then buff.allowedRoles = {} end
+		if buff.showStacks == nil then
+			buff.showStacks = addon.db["buffTrackerShowStacks"]
+			if buff.showStacks == nil then buff.showStacks = true end
+		end
+		if buff.showTimerText == nil then
+			buff.showTimerText = addon.db["buffTrackerShowTimerText"]
+			if buff.showTimerText == nil then buff.showTimerText = true end
+		end
+	end
 end


### PR DESCRIPTION
## Summary
- add `showStacks` and `showTimerText` to buff records
- initialise existing buffs with these new fields
- expose these options per-aura in the UI
- respect per-aura values when updating buff frames

## Testing
- `luacheck EnhanceQoLAura/BuffTracker.lua EnhanceQoLAura/Init.lua`


------
https://chatgpt.com/codex/tasks/task_e_68748cb98e148329bc707b17f2e9d3f1