### PR TITLE
Implement timed buff refresh ticker

### DIFF
--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -31,6 +31,10 @@ local auraInstanceMap = {}
 local altToBase = {}
 local spellToCat = {}
 
+local timedAuras = {}
+local timeTicker
+local refreshTimeTicker
+
 local LSM = LibStub("LibSharedMedia-3.0")
 
 local specNames = {}
@@ -346,12 +350,20 @@ local function playBuffSound(catId, baseId, altId)
 end
 
 local function updateBuff(catId, id, changedId)
-	local cat = getCategory(catId)
-	local buff = cat and cat.buffs and cat.buffs[id]
-	if buff and not buffAllowed(buff) then
-		if activeBuffFrames[catId] and activeBuffFrames[catId][id] then activeBuffFrames[catId][id]:Hide() end
-		return
-	end
+        local cat = getCategory(catId)
+        local buff = cat and cat.buffs and cat.buffs[id]
+        local key = catId .. ":" .. id
+        local before = timedAuras[key] ~= nil
+        if buff and buff.timeOp and buff.timeVal then
+                timedAuras[key] = { catId = catId, buffId = id }
+        else
+                timedAuras[key] = nil
+        end
+        if before ~= (timedAuras[key] ~= nil) and refreshTimeTicker then refreshTimeTicker() end
+        if buff and not buffAllowed(buff) then
+                if activeBuffFrames[catId] and activeBuffFrames[catId][id] then activeBuffFrames[catId][id]:Hide() end
+                return
+        end
 
 	local aura
 	local triggeredId = id
@@ -520,12 +532,27 @@ local function updateBuff(catId, id, changedId)
 	end
 end
 
+refreshTimeTicker = function()
+        if timeTicker then
+                timeTicker:Cancel()
+                timeTicker = nil
+        end
+        if next(timedAuras) then
+                timeTicker = C_Timer.NewTicker(1, function()
+                        for _, info in pairs(timedAuras) do
+                                updateBuff(info.catId, info.buffId)
+                        end
+                end)
+        end
+end
+
 local function scanBuffs()
-	for catId, cat in pairs(addon.db["buffTrackerCategories"]) do
-		if addon.db["buffTrackerEnabled"][catId] and categoryAllowed(cat) then
-			for id in pairs(cat.buffs) do
-				if not addon.db["buffTrackerHidden"][id] then
-					updateBuff(catId, id)
+        wipe(timedAuras)
+        for catId, cat in pairs(addon.db["buffTrackerCategories"]) do
+                if addon.db["buffTrackerEnabled"][catId] and categoryAllowed(cat) then
+                        for id in pairs(cat.buffs) do
+                                if not addon.db["buffTrackerHidden"][id] then
+                                        updateBuff(catId, id)
 				elseif activeBuffFrames[catId] and activeBuffFrames[catId][id] then
 					activeBuffFrames[catId][id]:Hide()
 				end
@@ -537,10 +564,11 @@ local function scanBuffs()
 			if activeBuffFrames[catId] then
 				for _, frame in pairs(activeBuffFrames[catId]) do
 					frame:Hide()
-				end
-			end
-		end
-	end
+                        end
+                end
+        end
+       end
+       refreshTimeTicker()
 end
 
 addon.Aura.buffAnchors = anchors


### PR DESCRIPTION
## Summary
- track buffs with time-based conditions in `timedAuras`
- periodically update these auras via `refreshTimeTicker`
- rebuild timer set whenever buffs are scanned

## Testing
- `luacheck EnhanceQoLAura/BuffTracker.lua`

------
https://chatgpt.com/codex/tasks/task_e_68749a18f0f48329a2e532bc01787c65