### PR TITLE
Add default defensive aura IDs

### DIFF
--- a/EnhanceQoLAura/Init.lua
+++ b/EnhanceQoLAura/Init.lua
@@ -12,6 +12,38 @@ addon.Aura.variables = {}
 addon.Aura.sounds = {}
 addon.LAura = {} -- Locales for aura
 
+-- Default defensive abilities tracked on unit frames
+addon.Aura.defaults = {}
+-- IDs here are placeholders and should be replaced with actual spell IDs
+addon.Aura.defaults.defensiveSpellIDs = {
+	-- Warrior
+	[999001] = "Shield Wall",
+	-- Paladin
+	[999002] = "Divine Shield",
+	-- Death Knight
+	[999003] = "Icebound Fortitude",
+	-- Druid
+	[999004] = "Barkskin",
+	-- Demon Hunter
+	[999005] = "Blur",
+	-- Evoker
+	[999006] = "Obsidian Scales",
+	-- Hunter
+	[999007] = "Survival of the Fittest",
+	-- Mage
+	[999008] = "Ice Block",
+	-- Monk
+	[999009] = "Fortifying Brew",
+	-- Priest
+	[999010] = "Dispersion",
+	-- Rogue
+	[999011] = "Evasion",
+	-- Shaman
+	[999012] = "Astral Shift",
+	-- Warlock
+	[999013] = "Unending Resolve",
+}
+
 addon.functions.InitDBValue("AuraCooldownTrackerBarHeight", 30)
 addon.functions.InitDBValue("AuraSafedZones", {})
 addon.functions.InitDBValue("personalResourceBarHealth", {})

--- a/EnhanceQoLAura/UnitFrameAura.lua
+++ b/EnhanceQoLAura/UnitFrameAura.lua
@@ -50,7 +50,7 @@ local function UpdateTrackedBuffs(frame, unit)
 
 	local index = 0
 	AuraUtil.ForEachAura(unit, "HELPFUL", nil, function(_, icon, _, _, _, _, _, _, _, spellId)
-		if addon.db.unitFrameAuraIDs[spellId] then
+		if addon.db.unitFrameAuraIDs[spellId] or addon.Aura.defaults.defensiveSpellIDs[spellId] then
 			index = index + 1
 			local iconFrame = ensureIcon(frame, index)
 			iconFrame.icon:SetTexture(icon)
@@ -78,6 +78,18 @@ end
 
 addon.Aura.unitFrame.RefreshAll = RefreshAll
 
+local function getMergedAuraIDs()
+	local merged = {}
+	for id, name in pairs(addon.Aura.defaults.defensiveSpellIDs or {}) do
+		local info = C_Spell.GetSpellInfo(id)
+		merged[id] = string.format("%s (%d)", info or name or "Spell", id)
+	end
+	for id, val in pairs(addon.db.unitFrameAuraIDs or {}) do
+		merged[id] = val
+	end
+	return merged
+end
+
 -- Hook the global update function once; Blizzard calls this for every CompactUnitFrame
 hooksecurefunc("CompactUnitFrame_UpdateAuras", function(frame)
 	-- 'displayedUnit' is the unit token Blizzard uses; fall back to frame.unit
@@ -92,7 +104,7 @@ function addon.Aura.functions.addUnitFrameAuraOptions(container)
 
 	local drop
 	local function refresh()
-		local list, order = addon.functions.prepareListForDropdown(addon.db.unitFrameAuraIDs)
+		local list, order = addon.functions.prepareListForDropdown(getMergedAuraIDs())
 		drop:SetList(list, order)
 		drop:SetValue(nil)
 		RefreshAll()
@@ -111,7 +123,7 @@ function addon.Aura.functions.addUnitFrameAuraOptions(container)
 	end)
 	wrapper:AddChild(edit)
 
-	local list, order = addon.functions.prepareListForDropdown(addon.db.unitFrameAuraIDs)
+	local list, order = addon.functions.prepareListForDropdown(getMergedAuraIDs())
 	drop = addon.functions.createDropdownAce(L["TrackedAuras"], list, order, nil)
 	wrapper:AddChild(drop)
 


### PR DESCRIPTION
## Summary
- add a defaults table with placeholder spell IDs for class defensive skills
- merge these defaults with user entries in the UnitFrame aura dropdown

## Testing
- `luacheck EnhanceQoLAura/Init.lua EnhanceQoLAura/UnitFrameAura.lua`

------
https://chatgpt.com/codex/tasks/task_e_68751b61e5f88329884c8bc9bc54b8fd