### PR TITLE
Add unit-frame name truncation and scaling options

### DIFF
--- a/EnhanceQoL/Init.lua
+++ b/EnhanceQoL/Init.lua
@@ -3,6 +3,8 @@ _G[addonName] = addon
 addon.saveVariables = {} -- Cross-Module variables for DB Save
 addon.saveVariables["hidePlayerFrame"] = false -- Default for hiding the Player Frame
 addon.saveVariables["hideRaidFrameBuffs"] = false -- Default for hiding buffs on raid-style frames
+addon.saveVariables["unitFrameTruncateNames"] = false -- Default for truncating unit names
+addon.saveVariables["unitFrameScaleEnabled"] = false -- Default for scaling compact unit frames
 addon.gossip = {}
 addon.gossip.variables = {}
 addon.variables = {}
@@ -513,6 +515,8 @@ addon.variables.catalystID = nil -- Change to get the actual cataclyst charges i
 addon.variables.durabilityIcon = 136241 -- Anvil Symbol
 addon.variables.durabilityCount = 0
 addon.variables.hookedOrderHall = false
+addon.variables.unitFrameMaxNameLength = 6 -- default truncation length
+addon.variables.unitFrameScale = 1 -- default compact frame scale
 addon.variables.maxLevel = GetMaxLevelForPlayerExpansion()
 addon.variables.statusTable = { groups = {} }
 

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -176,6 +176,10 @@ L["showLeaderIconRaidFrame"] = "Show leader icon on raid-style party frames"
 L["showPartyFrameInSoloContent"] = "Show Party Frames in Solo Content"
 L["hidePlayerFrame"] = "Hide Player Frame"
 L["hideRaidFrameBuffs"] = "Hide buffs on raid-style frames"
+L["unitFrameTruncateNames"] = "Truncate unit names"
+L["unitFrameMaxNameLength"] = "Maximum name length"
+L["unitFrameScaleEnable"] = "Enable frame scale adjustment"
+L["unitFrameScale"] = "Frame scale"
 
 L["ActionbarHideExplain"] = 'Set the action bar to hidden and show on mouseover. This works only when your Action Bar is set to "%s" and "%s" in %s'
 

--- a/docs/OptionsReference.md
+++ b/docs/OptionsReference.md
@@ -51,6 +51,8 @@ Each action bar can be set to appear only on mouseover:
 - **Hide floating combat text over your character** (Hide floating combat text (damage and healing) over your character).
 - **Hide floating combat text over your pet** (Hide floating combat text (damage and healing) over your pet).
 - Additional options allow Target, Player or Boss frames to remain hidden until the mouse is over them.
+- **Truncate unit names** and set a **maximum name length**.
+- **Enable frame scale adjustment** with a slider to change the size of compact unit frames.
 
 ## Minimap & Micro Menu
 - **Enable quick switching for loot and active specializations** (Enable quick switching for loot and active specializations on the Minimap).


### PR DESCRIPTION
## Summary
- allow truncating compact unit names
- allow adjusting compact frame scale
- add sliders and checkboxes for new options
- document unit frame tweaks

## Testing
- `stylua EnhanceQoL/Init.lua EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`
- `luacheck EnhanceQoL/Init.lua EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`

------
https://chatgpt.com/codex/tasks/task_e_68751de9c7dc83299d75ecbc0374cdf2