### PR TITLE
Add unit frame tracker disabling

### DIFF
--- a/EnhanceQoLAura/Init.lua
+++ b/EnhanceQoLAura/Init.lua
@@ -87,6 +87,7 @@ for tId, tracker in pairs(addon.db["unitFrameAuraTrackers"]) do
 		if not tContains(addon.db.unitFrameAuraOrder[tId], id) then table.insert(addon.db.unitFrameAuraOrder[tId], id) end
 	end
 	tracker.spells = newSpells
+	if addon.db.unitFrameAuraEnabled[tId] == nil then addon.db.unitFrameAuraEnabled[tId] = true end
 end
 
 addon.Aura = {}
@@ -133,6 +134,7 @@ addon.functions.InitDBValue("unitFrameAuraShowTime", false)
 addon.functions.InitDBValue("unitFrameAuraShowSwipe", true)
 addon.functions.InitDBValue("unitFrameAuraTrackers", nil)
 addon.functions.InitDBValue("unitFrameAuraSelectedTracker", 1)
+addon.functions.InitDBValue("unitFrameAuraEnabled", {})
 
 if type(addon.db["buffTrackerSelectedCategory"]) ~= "number" then addon.db["buffTrackerSelectedCategory"] = 1 end
 


### PR DESCRIPTION
## Summary
- allow disabling UnitFrameAura trackers
- update UI to toggle trackers on/off
- refresh unit frame auras when removing an aura

## Testing
- `stylua EnhanceQoLAura/Init.lua EnhanceQoLAura/UnitFrameAura.lua`
- `luacheck EnhanceQoLAura/Init.lua EnhanceQoLAura/UnitFrameAura.lua`

------
https://chatgpt.com/codex/tasks/task_e_68753dd996a483299a8e2d1142784587