### PR TITLE
Fix BuffTracker usability issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Unit-Frame settings have been moved into their own *Unit Frame* category.
 ### 🐛 Fixed
 - Performance issue when *Hide buffs on raid-style frames* was enabled.
+- Error in TOC-Files
 
 ## [3.27.0] – 2025-07-11
 ### ✨ Added

--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -13,13 +13,16 @@ local AceGUI = addon.AceGUI
 local selectedCategory = addon.db["buffTrackerSelectedCategory"] or 1
 
 for _, cat in pairs(addon.db["buffTrackerCategories"]) do
-	for _, buff in pairs(cat.buffs or {}) do
-		if not buff.trackType then buff.trackType = "BUFF" end
-		if not buff.allowedSpecs then buff.allowedSpecs = {} end
-		if not buff.allowedClasses then buff.allowedClasses = {} end
-		if not buff.allowedRoles then buff.allowedRoles = {} end
-		if not buff.conditions then buff.conditions = { join = "AND", conditions = {} } end
-	end
+        for _, buff in pairs(cat.buffs or {}) do
+                if not buff.trackType then buff.trackType = "BUFF" end
+                if not buff.allowedSpecs then buff.allowedSpecs = {} end
+                if not buff.allowedClasses then buff.allowedClasses = {} end
+                if not buff.allowedRoles then buff.allowedRoles = {} end
+                if not buff.conditions then buff.conditions = { join = "AND", conditions = {} } end
+        end
+        cat.allowedSpecs = nil
+        cat.allowedClasses = nil
+        cat.allowedRoles = nil
 end
 
 local anchors = {}
@@ -252,7 +255,7 @@ local function ensureAnchor(id)
 	anchor:RegisterForDrag("LeftButton")
 	anchor.text = anchor:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
 	anchor.text:SetPoint("CENTER", anchor, "CENTER")
-	anchor.text:SetText(L["DragToPosition"])
+    anchor.text:SetText(string.format("Drag me\n%s", "|cffffd700" .. (cat.name or "") .. "|r"))
 
 	anchor:SetScript("OnDragStart", anchor.StartMoving)
 	anchor:SetScript("OnDragStop", function(self)
@@ -337,10 +340,15 @@ local function applySize(id)
 	local size = cat.size
 	anchor:SetSize(size, size)
 	activeBuffFrames[id] = activeBuffFrames[id] or {}
-	for _, frame in pairs(activeBuffFrames[id]) do
-		frame:SetSize(size, size)
-		frame.cd:SetAllPoints(frame)
-	end
+        for buffId, frame in pairs(activeBuffFrames[id]) do
+                frame:SetSize(size, size)
+                frame.cd:SetAllPoints(frame)
+                if frame.SpellActivationAlert then
+                        ActionButton_HideOverlayGlow(frame)
+                        local buff = cat.buffs and cat.buffs[buffId]
+                        if buff and buff.glow and frame.isActive then ActionButton_ShowOverlayGlow(frame) end
+                end
+        end
 	updatePositions(id)
 end
 
@@ -887,11 +895,13 @@ function addon.Aura.functions.buildCategoryOptions(container, catId)
 	end)
 	core:AddChild(lockCB)
 
-	local nameEdit = addon.functions.createEditboxAce(L["CategoryName"], cat.name, function(self, _, text)
-		if text ~= "" then cat.name = text end
-		refreshTree(catId)
-	end)
-	core:AddChild(nameEdit)
+        local nameEdit = addon.functions.createEditboxAce(L["CategoryName"], cat.name, function(self, _, text)
+                if text ~= "" then cat.name = text end
+                refreshTree(catId)
+                container:ReleaseChildren()
+                addon.Aura.functions.buildCategoryOptions(container, catId)
+        end)
+        core:AddChild(nameEdit)
 
 	local sizeSlider = addon.functions.createSliderAce(L["buffTrackerIconSizeHeadline"] .. ": " .. cat.size, cat.size, 0, 100, 1, function(self, _, val)
 		cat.size = val
@@ -940,10 +950,11 @@ function addon.Aura.functions.buildCategoryOptions(container, catId)
 				anchors[catId]:Hide()
 				anchors[catId] = nil
 			end
-			selectedCategory = next(addon.db["buffTrackerCategories"]) or 1
-			rebuildAltMapping()
-			refreshTree(selectedCategory)
-		end
+                        selectedCategory = next(addon.db["buffTrackerCategories"]) or 1
+                        rebuildAltMapping()
+                        refreshTree(selectedCategory)
+                        if treeGroup then treeGroup:SelectByValue(tostring(selectedCategory)) end
+                end
 		StaticPopup_Show("EQOL_DELETE_CATEGORY", catName)
 	end)
 	core:AddChild(delBtn)
@@ -1226,17 +1237,29 @@ function addon.Aura.functions.buildBuffOptions(container, catId, buffId)
 		wrapper:AddChild(row)
 	end
 
-	local altEdit = addon.functions.createEditboxAce(L["AddAltSpellID"], nil, function(self, _, text)
-		local alt = tonumber(text)
-		if alt then
-			if not tContains(buff.altIDs, alt) then table.insert(buff.altIDs, alt) end
-			rebuildAltMapping()
-			self:SetText("")
-			container:ReleaseChildren()
-			addon.Aura.functions.buildBuffOptions(container, catId, buffId)
-		end
-	end)
-	wrapper:AddChild(altEdit)
+        local altEdit = addon.functions.createEditboxAce(L["AddAltSpellID"], nil, function(self, _, text)
+                local alt = tonumber(text)
+                if alt then
+                        if not tContains(buff.altIDs, alt) then table.insert(buff.altIDs, alt) end
+                        rebuildAltMapping()
+                        self:SetText("")
+                        container:ReleaseChildren()
+                        addon.Aura.functions.buildBuffOptions(container, catId, buffId)
+                end
+        end)
+        wrapper:AddChild(altEdit)
+
+        local infoIcon = AceGUI:Create("Icon")
+        infoIcon:SetImage("Interface\\FriendsFrame\\InformationIcon")
+        infoIcon:SetImageSize(16, 16)
+        infoIcon:SetWidth(16)
+        infoIcon:SetCallback("OnEnter", function(widget)
+                GameTooltip:SetOwner(widget.frame, "ANCHOR_RIGHT")
+                GameTooltip:SetText("Alternative spell IDs are treated as the same aura. Use this to track multiple IDs of one spell.")
+                GameTooltip:Show()
+        end)
+        infoIcon:SetCallback("OnLeave", function() GameTooltip:Hide() end)
+        wrapper:AddChild(infoIcon)
 
 	wrapper:AddChild(addon.functions.createSpacerAce())
 
@@ -1279,9 +1302,10 @@ function addon.Aura.functions.addBuffTrackerOptions(container)
 				direction = "RIGHT",
 				buffs = {},
 			}
-			ensureAnchor(newId)
-			refreshTree(newId) -- rebuild tree and select new node
-			return -- don’t build options for pseudo‑node
+                        ensureAnchor(newId)
+                        refreshTree(newId)
+                        if treeGroup then treeGroup:SelectByValue(tostring(newId)) end
+                        return -- don’t build options for pseudo‑node
 		end
 
 		local catId, _, buffId = strsplit("\001", value)

--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -966,6 +966,7 @@ function addon.Aura.functions.buildCategoryOptions(container, catId)
 			rebuildAltMapping()
 			refreshTree(selectedCategory)
 			if treeGroup then treeGroup:SelectByValue(tostring(selectedCategory)) end
+			container:ReleaseChildren()
 		end
 		StaticPopup_Show("EQOL_DELETE_CATEGORY", catName)
 	end)

--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -894,14 +894,18 @@ function addon.Aura.functions.buildCategoryOptions(container, catId)
 		applyLockState()
 		scanBuffs()
 		refreshTree(selectedCategory)
+		container:ReleaseChildren()
+		addon.Aura.functions.buildCategoryOptions(container, catId)
 	end)
 	core:AddChild(enableCB)
 
-	local lockCB = addon.functions.createCheckboxAce(L["buffTrackerLocked"], addon.db["buffTrackerLocked"][catId], function(self, _, val)
-		addon.db["buffTrackerLocked"][catId] = val
-		applyLockState()
-	end)
-	core:AddChild(lockCB)
+	if addon.db["buffTrackerEnabled"][catId] then
+		local lockCB = addon.functions.createCheckboxAce(L["buffTrackerLocked"], addon.db["buffTrackerLocked"][catId], function(self, _, val)
+			addon.db["buffTrackerLocked"][catId] = val
+			applyLockState()
+		end)
+		core:AddChild(lockCB)
+	end
 
 	local nameEdit = addon.functions.createEditboxAce(L["CategoryName"], cat.name, function(self, _, text)
 		if text ~= "" then

--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -829,7 +829,12 @@ end
 local function refreshTree(selectValue)
 	if not treeGroup then return end
 	treeGroup:SetTree(getCategoryTree())
-	if selectValue then treeGroup:SelectByValue(tostring(selectValue)) end
+	if selectValue then 
+		treeGroup:SelectByValue(tostring(selectValue)) 
+		-- C_Timer.After(0, function() 
+			treeGroup:Select(selectValue)
+		--  end)
+	end
 end
 
 local function handleDragDrop(src, dst)

--- a/EnhanceQoLAura/Locales/enUS.lua
+++ b/EnhanceQoLAura/Locales/enUS.lua
@@ -1,7 +1,7 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_Aura", "enUS", true) -- “true” = default / fallback
 
 L["Aura"] = "Aura"
-L["DragToPosition"] = "Drag me to position"
+L["DragToPosition"] = "Drag me\n%s"
 L["BuffTracker"] = "Aura Tracker"
 L["EnableBuffTracker"] = 'Enable Aura Tracker "%s"'
 L["GrowthDirection"] = "Growth Direction"


### PR DESCRIPTION
## Summary
- show category name on drag anchor
- resize overlay glow when icon size changes
- rebuild category UI when renamed
- ensure category deletion jumps to a valid node
- auto-select new category after creation
- add info icon for alternative spell IDs
- remove legacy category role/spec/class filters

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_68762f249ea48329a4b380d6ab56d9d8