### PR TITLE
Fix new buff tracker category selection

### DIFF
--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -829,6 +829,7 @@ end
 local function refreshTree(selectValue)
 	if not treeGroup then return end
 	treeGroup:SetTree(getCategoryTree())
+	if selectValue then treeGroup:SelectByValue(tostring(selectValue)) end
 end
 
 local function handleDragDrop(src, dst)
@@ -965,7 +966,6 @@ function addon.Aura.functions.buildCategoryOptions(container, catId)
 			selectedCategory = next(addon.db["buffTrackerCategories"]) or 1
 			rebuildAltMapping()
 			refreshTree(selectedCategory)
-			if treeGroup then treeGroup:SelectByValue(tostring(selectedCategory)) end
 			container:ReleaseChildren()
 		end
 		StaticPopup_Show("EQOL_DELETE_CATEGORY", catName)
@@ -1319,7 +1319,6 @@ function addon.Aura.functions.addBuffTrackerOptions(container)
 			addon.db["buffTrackerLocked"][newId] = false
 			ensureAnchor(newId)
 			refreshTree(newId)
-			if treeGroup then treeGroup:SelectByValue(tostring(newId)) end
 			return -- don’t build options for pseudo‑node
 		end
 


### PR DESCRIPTION
## Summary
- ensure tree selection persists when refreshing buff tracker categories
- remove redundant selection code when adding or deleting categories

## Testing
- `stylua EnhanceQoLAura/BuffTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_687634a424888329b56728a24851a85a