### PR TITLE
Fix buff tracker import/export issues

### DIFF
--- a/EnhanceQoLAura/Locales/enUS.lua
+++ b/EnhanceQoLAura/Locales/enUS.lua
@@ -46,3 +46,4 @@ L["AlternativeSpellInfo"] = "Alternative spell IDs are treated as the same aura.
 L["ExportCategory"] = "Export Category"
 L["ImportCategory"] = "Import Category"
 L["ImportCategoryError"] = "Invalid category string"
+L["ImportCategoryMissingSounds"] = "The following sound files were not imported: %s"


### PR DESCRIPTION
## Summary
- preserve custom sound info when exporting and importing Aura Tracker categories
- warn when imported sounds are missing
- ensure category IDs don't overwrite existing ones
- make import/export/delete popups appear above options window
- add translation string for missing sounds message

## Testing
- `luacheck EnhanceQoLAura/BuffTracker.lua EnhanceQoLAura/Locales/enUS.lua`


------
https://chatgpt.com/codex/tasks/task_e_68772ed7b5548329bb2e37d99ed10a35