### PR TITLE
Implement spec-based resource bar configuration

### DIFF
--- a/EnhanceQoLAura/Init.lua
+++ b/EnhanceQoLAura/Init.lua
@@ -13,6 +13,9 @@ addon.Aura.sounds = {}
 addon.LAura = {} -- Locales for aura
 local L = LibStub("AceLocale-3.0"):GetLocale("EnhanceQoL_Aura")
 
+-- spec specific settings for personal resource bars
+addon.functions.InitDBValue("personalResourceBarSettings", {})
+
 addon.functions.InitDBValue("buffTrackerCategories", {
 	[1] = {
 		name = string.format("%s", L["Example"]),


### PR DESCRIPTION
## Summary
- enable saved variable for spec-based resource bar settings
- expose powertype data and read per-spec settings for power bars
- support text style, width and height per power type
- add configuration UI with spec tabs

## Testing
- `luacheck EnhanceQoLAura`

------
https://chatgpt.com/codex/tasks/task_e_68781580544c832989f3fc61c0b028b3