### PR TITLE
Fix ResourceBars loading order

### DIFF
--- a/EnhanceQoLAura/EnhanceQoLAura.toc
+++ b/EnhanceQoLAura/EnhanceQoLAura.toc
@@ -24,6 +24,6 @@ locales.xml
 Init.lua
 ..\EnhanceQoL\widgets\DragTreeGroup.lua
 
-EnhanceQoLAura.lua
 ResourceBars.lua
+EnhanceQoLAura.lua
 BuffTracker.lua


### PR DESCRIPTION
## Summary
- load `ResourceBars.lua` before `EnhanceQoLAura.lua`

## Testing
- `stylua --check EnhanceQoLAura/EnhanceQoLAura.lua`


------
https://chatgpt.com/codex/tasks/task_e_687863b04ec883298e915d0d28716ab3