### PR TITLE
Improve resource bar anchoring

### DIFF
--- a/EnhanceQoLAura/EnhanceQoLAura.lua
+++ b/EnhanceQoLAura/EnhanceQoLAura.lua
@@ -133,14 +133,15 @@ local function addResourceFrame(container)
 			"BOTTOMRIGHT",
 		}
 
-		local frameList = {
+		local baseFrameList = {
 			UIParent = "UIParent",
 			PlayerFrame = "PlayerFrame",
 			TargetFrame = "TargetFrame",
 		}
 
-		local function addAnchorOptions(barType, parent, info)
+		local function addAnchorOptions(barType, parent, info, frameList)
 			info = info or {}
+			frameList = frameList or baseFrameList
 
 			local header = addon.functions.createLabelAce(barType .. " Anchor")
 			parent:AddChild(header)
@@ -239,7 +240,16 @@ local function addResourceFrame(container)
 					drop:SetValue(cfg.textStyle)
 					container:AddChild(drop)
 
-					addAnchorOptions(real, container, cfg.anchor)
+					local frames = {}
+					for k, v in pairs(baseFrameList) do
+						frames[k] = v
+					end
+					frames.EQOLHealthBar = "EQOLHealthBar"
+					for _, t in ipairs(addon.Aura.ResourceBars.classPowerTypes) do
+						if dbSpec[t] and dbSpec[t].enabled ~= false then frames["EQOL" .. t .. "Bar"] = "EQOL" .. t .. "Bar" end
+					end
+
+					addAnchorOptions(real, container, cfg.anchor, frames)
 
 					container:AddChild(addon.functions.createSpacerAce())
 				end


### PR DESCRIPTION
## Summary
- let resource bars anchor to other EQOL bars in the options UI
- detect loops when resolving anchors so bars fall back to `UIParent`

## Testing
- `stylua EnhanceQoLAura/ResourceBars.lua EnhanceQoLAura/EnhanceQoLAura.lua`

------
https://chatgpt.com/codex/tasks/task_e_68786c36779483298bc6c0e263d8aa16