### PR TITLE
Fix resource bar refresh after text style change

### DIFF
--- a/EnhanceQoLAura/EnhanceQoLAura.lua
+++ b/EnhanceQoLAura/EnhanceQoLAura.lua
@@ -227,7 +227,10 @@ local function addResourceFrame(container)
 
 					local tList = { PERCENT = "Percentage", CURMAX = "Current/Max", CURRENT = "Current" }
 					local tOrder = { "PERCENT", "CURMAX", "CURRENT" }
-					local drop = addon.functions.createDropdownAce("Text", tList, tOrder, function(self, _, key) cfg.textStyle = key end)
+					local drop = addon.functions.createDropdownAce("Text", tList, tOrder, function(self, _, key)
+						cfg.textStyle = key
+						addon.Aura.ResourceBars.Refresh()
+					end)
 					drop:SetValue(cfg.textStyle)
 					container:AddChild(drop)
 
@@ -276,5 +279,3 @@ function addon.Aura.functions.treeCallback(container, group)
 		addon.Aura.scanBuffs()
 	end
 end
-
-


### PR DESCRIPTION
## Summary
- ensure text style dropdown refreshes visible resource bars

## Testing
- `luacheck EnhanceQoLAura`

------
https://chatgpt.com/codex/tasks/task_e_68786f543090832996b5137b6a5ee740