### PR TITLE
Add font size option for resource bars

### DIFF
--- a/EnhanceQoLAura/EnhanceQoLAura.lua
+++ b/EnhanceQoLAura/EnhanceQoLAura.lua
@@ -203,6 +203,7 @@ local function addResourceFrame(container)
 							width = addon.db["personalResourceBarManaWidth"],
 							height = addon.db["personalResourceBarManaHeight"],
 							textStyle = real == "MANA" and "PERCENT" or "CURMAX",
+							fontSize = 16,
 						}
 					dbSpec[real].anchor = dbSpec[real].anchor or {}
 
@@ -233,6 +234,12 @@ local function addResourceFrame(container)
 					end)
 					drop:SetValue(cfg.textStyle)
 					container:AddChild(drop)
+
+					local sFont = addon.functions.createSliderAce("Text Size", cfg.fontSize or 16, 6, 64, 1, function(self, _, val)
+						cfg.fontSize = val
+						addon.Aura.ResourceBars.Refresh()
+					end)
+					container:AddChild(sFont)
 
 					local frames = {}
 					for k, v in pairs(baseFrameList) do

--- a/EnhanceQoLAura/ResourceBars.lua
+++ b/EnhanceQoLAura/ResourceBars.lua
@@ -16,6 +16,7 @@ local mainFrame
 local healthBar
 local powerbar = {}
 local powerfrequent = {}
+local getBarSettings
 
 local function getPowerBarColor(type)
 	local powerKey = string.upper(type)
@@ -113,8 +114,11 @@ local function createHealthBar()
 	})
 	healthBar:SetBackdropColor(0, 0, 0, 0.8)
 	healthBar:SetBackdropBorderColor(0, 0, 0, 0)
+	local settings = getBarSettings("HEALTH")
+	local fontSize = settings and settings.fontSize or 16
+
 	healthBar.text = healthBar:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-	healthBar.text:SetFont(addon.variables.defaultFont, 16, "OUTLINE")
+	healthBar.text:SetFont(addon.variables.defaultFont, fontSize, "OUTLINE")
 	healthBar.text:SetPoint("CENTER", healthBar, "CENTER", 3, 0)
 
 	healthBar:SetMovable(true)
@@ -233,7 +237,7 @@ local classPowerTypes = {
 ResourceBars.powertypeClasses = powertypeClasses
 ResourceBars.classPowerTypes = classPowerTypes
 
-local function getBarSettings(pType)
+function getBarSettings(pType)
 	local class = addon.variables.unitClass
 	local spec = addon.variables.unitSpec
 	if addon.db.personalResourceBarSettings and addon.db.personalResourceBarSettings[class] and addon.db.personalResourceBarSettings[class][spec] then
@@ -305,8 +309,10 @@ local function createPowerBar(type, anchor)
 	})
 	bar:SetBackdropColor(0, 0, 0, 0.8)
 	bar:SetBackdropBorderColor(0, 0, 0, 0)
+	local fontSize = settings and settings.fontSize or 16
+
 	bar.text = bar:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-	bar.text:SetFont(addon.variables.defaultFont, 16, "OUTLINE")
+	bar.text:SetFont(addon.variables.defaultFont, fontSize, "OUTLINE")
 	bar.text:SetPoint("CENTER", bar, "CENTER", 3, 0)
 	bar:SetStatusBarColor(getPowerBarColor(type))
 


### PR DESCRIPTION
## Summary
- allow per-bar font size configuration with a slider
- apply configured font size when creating health and power bars

## Testing
- `stylua .`
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_687870448ffc83299bbd0b7e7d004336