### PR TITLE
Fix anchor options for resource bars

### DIFF
--- a/EnhanceQoLAura/EnhanceQoLAura.lua
+++ b/EnhanceQoLAura/EnhanceQoLAura.lua
@@ -258,14 +258,16 @@ local function addResourceFrame(container)
 						end)
 						container:AddChild(sFont)
 
-						local frames = {}
-						for k, v in pairs(baseFrameList) do
-							frames[k] = v
-						end
-						frames.EQOLHealthBar = "EQOLHealthBar"
-						for _, t in ipairs(addon.Aura.ResourceBars.classPowerTypes) do
-							if dbSpec[t] and dbSpec[t].enabled ~= false then frames["EQOL" .. t .. "Bar"] = "EQOL" .. t .. "Bar" end
-						end
+                                                local frames = {}
+                                                for k, v in pairs(baseFrameList) do
+                                                        frames[k] = v
+                                                end
+                                                frames.EQOLHealthBar = "EQOLHealthBar"
+                                                for _, t in ipairs(addon.Aura.ResourceBars.classPowerTypes) do
+                                                        if t ~= real and dbSpec[t] and dbSpec[t].enabled ~= false then
+                                                                frames["EQOL" .. t .. "Bar"] = "EQOL" .. t .. "Bar"
+                                                        end
+                                                end
 
 						addAnchorOptions(real, container, cfg.anchor, frames)
 					end


### PR DESCRIPTION
## Summary
- prevent resource bars from being anchored to themselves

## Testing
- `luacheck . --no-color -q`

------
https://chatgpt.com/codex/tasks/task_e_68788730381c8329bca9da3f7acf81bb