### PR TITLE
Handle anchors when disabling resource bars

### DIFF
--- a/EnhanceQoLAura/EnhanceQoLAura.lua
+++ b/EnhanceQoLAura/EnhanceQoLAura.lua
@@ -224,6 +224,7 @@ local function addResourceFrame(container)
 					local cfg = dbSpec[real]
 					local label = _G[real] or real
 					local cb = addon.functions.createCheckboxAce(label, cfg.enabled, function(self, _, val)
+						if cfg.enabled and not val then addon.Aura.ResourceBars.DetachAnchorsFrom(real, specIndex) end
 						cfg.enabled = val
 						addon.Aura.ResourceBars.Refresh()
 						tabGroup:ReleaseChildren()
@@ -259,16 +260,14 @@ local function addResourceFrame(container)
 						end)
 						container:AddChild(sFont)
 
-                                                local frames = {}
-                                                for k, v in pairs(baseFrameList) do
-                                                        frames[k] = v
-                                                end
-                                                frames.EQOLHealthBar = "EQOLHealthBar"
-                                                for _, t in ipairs(addon.Aura.ResourceBars.classPowerTypes) do
-                                                        if t ~= real and dbSpec[t] and dbSpec[t].enabled ~= false then
-                                                                frames["EQOL" .. t .. "Bar"] = "EQOL" .. t .. "Bar"
-                                                        end
-                                                end
+						local frames = {}
+						for k, v in pairs(baseFrameList) do
+							frames[k] = v
+						end
+						frames.EQOLHealthBar = "EQOLHealthBar"
+						for _, t in ipairs(addon.Aura.ResourceBars.classPowerTypes) do
+							if t ~= real and dbSpec[t] and dbSpec[t].enabled ~= false then frames["EQOL" .. t .. "Bar"] = "EQOL" .. t .. "Bar" end
+						end
 
 						addAnchorOptions(real, container, cfg.anchor, frames)
 					end

--- a/EnhanceQoLAura/ResourceBars.lua
+++ b/EnhanceQoLAura/ResourceBars.lua
@@ -518,6 +518,36 @@ function ResourceBars.DisableResourceBars()
 	powerbar = {}
 end
 
+local function getFrameName(pType)
+	if pType == "HEALTH" then return "EQOLHealthBar" end
+	return "EQOL" .. pType .. "Bar"
+end
+
+function ResourceBars.DetachAnchorsFrom(disabledType, specIndex)
+	local class = addon.variables.unitClass
+	local spec = specIndex or addon.variables.unitSpec
+
+	if not addon.db.personalResourceBarSettings or not addon.db.personalResourceBarSettings[class] or not addon.db.personalResourceBarSettings[class][spec] then return end
+
+	local specCfg = addon.db.personalResourceBarSettings[class][spec]
+	local targetName = getFrameName(disabledType)
+
+	for pType, cfg in pairs(specCfg) do
+		if pType ~= disabledType and cfg.anchor and cfg.anchor.relativeFrame == targetName then
+			local frame = _G[getFrameName(pType)]
+			if frame then
+				cfg.anchor.point = "BOTTOMLEFT"
+				cfg.anchor.relativeFrame = "UIParent"
+				cfg.anchor.relativePoint = "BOTTOMLEFT"
+				cfg.anchor.x = frame:GetLeft() or 0
+				cfg.anchor.y = frame:GetBottom() or 0
+			else
+				cfg.anchor.relativeFrame = "UIParent"
+			end
+		end
+	end
+end
+
 function ResourceBars.SetHealthBarSize(w, h)
 	if healthBar then healthBar:SetSize(w, h) end
 end


### PR DESCRIPTION
## Summary
- add function to detach anchors referencing a disabled bar
- call it when a resource bar is unchecked in the options

## Testing
- `luacheck EnhanceQoLAura/ResourceBars.lua EnhanceQoLAura/EnhanceQoLAura.lua`

------
https://chatgpt.com/codex/tasks/task_e_68788e853d7083298c3a2caa6c1b6a00