### PR TITLE
Fix follower dungeon error when Shorten Names option is active

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -3278,11 +3278,16 @@ local function initUnitFrame()
 	end
 	hooksecurefunc("CompactUnitFrame_SetUpFrame", DisableBlizzBuffs)
 
-	local function TruncateFrameName(cuf)
-		if not addon.db["unitFrameTruncateNames"] then return end
-		if not addon.db["unitFrameMaxNameLength"] then return end
-		if cuf and cuf.name and cuf.name:GetText() then
-			local name = cuf.name:GetText()
+        local function TruncateFrameName(cuf)
+                if not addon.db["unitFrameTruncateNames"] then return end
+                if not addon.db["unitFrameMaxNameLength"] then return end
+                if cuf
+                        and cuf.name
+                        and type(cuf.name.GetText) == "function"
+                        and type(cuf.name.SetText) == "function"
+                        and cuf.name:GetText()
+                then
+                        local name = cuf.name:GetText()
 			-- Remove server names before truncation
 			local shortName = strsplit("-", name)
 			if #shortName > addon.db["unitFrameMaxNameLength"] then shortName = strsub(shortName, 1, addon.db["unitFrameMaxNameLength"]) end


### PR DESCRIPTION
## Summary
- avoid calling `:GetText` on an invalid `cuf.name` in `TruncateFrameName`

## Testing
- `luacheck EnhanceQoL/EnhanceQoL.lua --no-color -q`

------
https://chatgpt.com/codex/tasks/task_e_687929ffed188329a9d9b6a8c62262a5