### PR TITLE
Add vendor tooltip indicator

### DIFF
--- a/EnhanceQoLVendor/EnhanceQoLVendor.lua
+++ b/EnhanceQoLVendor/EnhanceQoLVendor.lua
@@ -607,3 +607,12 @@ hooksecurefunc(ContainerFrameCombinedBags, "UpdateItems", updateSellMarks)
 for _, frame in ipairs(ContainerFrameContainer.ContainerFrames) do
 	hooksecurefunc(frame, "UpdateItems", updateSellMarks)
 end
+
+hooksecurefunc(_G.ContainerFrameItemButtonMixin, "OnEnter", function(self)
+	local bag = self:GetBagID()
+	local slot = self:GetID()
+	if bag and slot and sellMarkLookup[bag .. "_" .. slot] then
+		GameTooltip:AddLine(L["vendorWillBeSold"], 1, 0, 0)
+		GameTooltip:Show()
+	end
+end)

--- a/EnhanceQoLVendor/Locales/enUS.lua
+++ b/EnhanceQoLVendor/Locales/enUS.lua
@@ -43,3 +43,4 @@ L["andWord"] = "and"
 L["vendorCraftingExpansions"] = "Include crafting materials (grouped by expansion)"
 
 L["vendorSellNext"] = "Sell next"
+L["vendorWillBeSold"] = "Will be sold"


### PR DESCRIPTION
## Summary
- mark items to be sold when hovering over them in bags
- add new locale string `vendorWillBeSold`

## Testing
- `luacheck EnhanceQoLVendor/EnhanceQoLVendor.lua EnhanceQoLVendor/Locales/enUS.lua`

------
https://chatgpt.com/codex/tasks/task_e_687fbb9b5a0c83299bf661f64ab48eb1