### PR TITLE
Optimize vendor item lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [3.32.0] – 2025-07-23
+### ✨ Added
+- **Vendor**
+  - Added option to display a small coin icon on items marked for auto-sell
+  - Added option to show an additional red overlay for clearer visual feedback
+  - Added option to display tooltip information on items marked for auto-sell
+### 🐛 Fixed
+- **Memory usage**
+  - Removed obsolete and duplicate function calls
+  - Replaced excessive API calls with leaner, more performant alternatives
+
 ## [3.31.0] – 2025-07-16
 ### ✨ Added
 - **Quick vendor include-list management**

--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -3278,16 +3278,11 @@ local function initUnitFrame()
 	end
 	hooksecurefunc("CompactUnitFrame_SetUpFrame", DisableBlizzBuffs)
 
-        local function TruncateFrameName(cuf)
-                if not addon.db["unitFrameTruncateNames"] then return end
-                if not addon.db["unitFrameMaxNameLength"] then return end
-                if cuf
-                        and cuf.name
-                        and type(cuf.name.GetText) == "function"
-                        and type(cuf.name.SetText) == "function"
-                        and cuf.name:GetText()
-                then
-                        local name = cuf.name:GetText()
+	local function TruncateFrameName(cuf)
+		if not addon.db["unitFrameTruncateNames"] then return end
+		if not addon.db["unitFrameMaxNameLength"] then return end
+		if cuf and cuf.name and type(cuf.name.GetText) == "function" and type(cuf.name.SetText) == "function" and cuf.name:GetText() then
+			local name = cuf.name:GetText()
 			-- Remove server names before truncation
 			local shortName = strsplit("-", name)
 			if #shortName > addon.db["unitFrameMaxNameLength"] then shortName = strsub(shortName, 1, addon.db["unitFrameMaxNameLength"]) end
@@ -4855,6 +4850,7 @@ local eventHandlers = {
 	end,
 	--@debug@
 	["BAG_UPDATE_DELAYED"] = function(arg1)
+		addon.functions.clearTooltipCache()
 		if addon.db["automaticallyOpenContainer"] then
 			if wOpen then return end
 			wOpen = true
@@ -4867,10 +4863,12 @@ local eventHandlers = {
 		if not addon.db["showIlvlOnBankFrame"] then return end
 		--TODO Removed global variable in Patch 11.2 - has to be removed everywhere when patch is released
 		if NUM_BANKGENERIC_SLOTS then
-			for slot = 1, NUM_BANKGENERIC_SLOTS do
-				local itemButton = _G["BankFrameItem" .. slot]
-				if itemButton then addon.functions.updateBank(itemButton, -1, slot) end
-			end
+			C_Timer.After(0, function()
+				for slot = 1, NUM_BANKGENERIC_SLOTS do
+					local itemButton = _G["BankFrameItem" .. slot]
+					if itemButton then addon.functions.updateBank(itemButton, -1, slot) end
+				end
+			end)
 		end
 	end,
 	["CURRENCY_DISPLAY_UPDATE"] = function(arg1)
@@ -4979,13 +4977,15 @@ local eventHandlers = {
 	end,
 	["INVENTORY_SEARCH_UPDATE"] = function()
 		if addon.db["showBagFilterMenu"] then
-			addon.functions.updateBags(ContainerFrameCombinedBags)
-			for _, frame in ipairs(ContainerFrameContainer.ContainerFrames) do
-				addon.functions.updateBags(frame)
-			end
-			--TODO AccountBankPanel is removed in 11.2 - Feature has to be removed everywhere after release
-			if _G.AccountBankPanel and _G.AccountBankPanel:IsShown() then addon.functions.updateBags(_G.AccountBankPanel) end
-			if _G.BankPanel and _G.BankPanel:IsShown() then addon.functions.updateBags(_G.BankPanel) end
+			C_Timer.After(0, function()
+				addon.functions.updateBags(ContainerFrameCombinedBags)
+				for _, frame in ipairs(ContainerFrameContainer.ContainerFrames) do
+					addon.functions.updateBags(frame)
+				end
+				--TODO AccountBankPanel is removed in 11.2 - Feature has to be removed everywhere after release
+				if _G.AccountBankPanel and _G.AccountBankPanel:IsShown() then addon.functions.updateBags(_G.AccountBankPanel) end
+				if _G.BankPanel and _G.BankPanel:IsShown() then addon.functions.updateBags(_G.BankPanel) end
+			end)
 		end
 	end,
 	["PARTY_INVITE_REQUEST"] = function(unitName, arg2, arg3, arg4, arg5, arg6, unitID, arg8)

--- a/EnhanceQoL/General/functions.lua
+++ b/EnhanceQoL/General/functions.lua
@@ -305,6 +305,44 @@ function addon.functions.addToTree(parentValue, newElement, noSort)
 end
 
 local knownButtons = {}
+local tooltipCache = {}
+local function getTooltipInfo(bag, slot)
+	local key = bag .. "_" .. slot
+	local cached = tooltipCache[key]
+	if cached then return cached[1], cached[2], cached[3], cached[4] end
+
+	local bType, bKey, upgradeKey, bAuc
+	local data = C_TooltipInfo.GetBagItem(bag, slot)
+	if data and data.lines then
+		for i, v in pairs(data.lines) do
+			if v.type == 20 then
+				bAuc = true
+				if v.leftText == ITEM_BIND_ON_EQUIP then
+					bType = "BoE"
+					bKey = "boe"
+					bAuc = false
+				elseif v.leftText == ITEM_ACCOUNTBOUND_UNTIL_EQUIP or v.leftText == ITEM_BIND_TO_ACCOUNT_UNTIL_EQUIP then
+					bType = "WuE"
+					bKey = "wue"
+				elseif v.leftText == ITEM_ACCOUNTBOUND or v.leftText == ITEM_BIND_TO_BNETACCOUNT then
+					bType = "WB"
+					bKey = "wb"
+				end
+			elseif v.type == 42 then
+				local text = v.rightText or v.leftText
+				if text then
+					local tier = text:gsub(".+:%s?", ""):gsub("%s?%d/%d", "")
+					if tier then upgradeKey = string.lower(tier) end
+				end
+			elseif v.type == 0 and v.leftText == ITEM_CONJURED then
+				bAuc = true
+			end
+		end
+	end
+
+	tooltipCache[key] = { bType, bKey, upgradeKey, bAuc }
+	return bType, bKey, upgradeKey, bAuc
+end
 
 local function updateButtonInfo(itemButton, bag, slot, frameName)
 	itemButton:SetAlpha(1)
@@ -315,158 +353,138 @@ local function updateButtonInfo(itemButton, bag, slot, frameName)
 		itemButton.ItemBoundType:SetAlpha(1)
 		itemButton.ItemBoundType:SetText("")
 	end
-	local eItem = Item:CreateFromBagAndSlot(bag, slot)
-	if eItem and not eItem:IsItemEmpty() then
-		eItem:ContinueOnItemLoad(function()
-			local _, _, _, _, _, _, _, _, itemEquipLoc, _, sellPrice, classID, subclassID, _, expId = GetItemInfo(eItem:GetItemLink())
-			local bType, bKey, upgradeKey, bAuc
-			local data
-			if addon.db["showBindOnBagItems"] or addon.itemBagFilters["bind"] or addon.itemBagFilters["upgrade"] or addon.itemBagFilters["misc_auctionhouse_sellable"] then
-				data = GetBagItem(bag, slot)
-				if data and data.lines then
-					for i, v in pairs(data.lines) do
-						if v.type == 20 then
-							bAuc = true
-							if v.leftText == ITEM_BIND_ON_EQUIP then
-								bType = "BoE"
-								bKey = "boe"
-								bAuc = false
-							elseif v.leftText == ITEM_ACCOUNTBOUND_UNTIL_EQUIP or v.leftText == ITEM_BIND_TO_ACCOUNT_UNTIL_EQUIP then
-								bType = "WuE"
-								bKey = "wue"
-							elseif v.leftText == ITEM_ACCOUNTBOUND or v.leftText == ITEM_BIND_TO_BNETACCOUNT then
-								bType = "WB"
-								bKey = "wb"
-							end
-						elseif v.type == 42 then
-							local text = v.rightText or v.leftText
-							if text then
-								local tier = text:gsub(".+:%s?", ""):gsub("%s?%d/%d", "")
-								if tier then upgradeKey = string.lower(tier) end
-							end
-						elseif v.type == 0 and v.leftText == ITEM_CONJURED then
-							bAuc = true
-						end
-					end
-				end
-			end
-			local setVisibility = false
+	local itemLink = C_Container.GetContainerItemLink(bag, slot)
+	-- local eItem = Item:CreateFromBagAndSlot(bag, slot)
+	-- if eItem and not eItem:IsItemEmpty() then
+	if itemLink then
+		-- eItem:ContinueOnItemLoad(function()
+		local _, _, itemQuality, _, _, _, _, _, itemEquipLoc, _, sellPrice, classID, subclassID, _, expId = GetItemInfo(itemLink)
 
-			if addon.filterFrame then
-				if classID == 15 and subclassID == 0 then bAuc = true end -- ignore lockboxes etc.
-				local cInfo = GetContainerItemInfo(bag, slot)
-				if cInfo and cInfo.isFiltered then setVisibility = true end
-				if addon.filterFrame:IsVisible() then
-					if addon.itemBagFilters["rarity"] then
-						if nil == addon.itemBagFiltersQuality[eItem:GetItemQuality()] or addon.itemBagFiltersQuality[eItem:GetItemQuality()] == false then setVisibility = true end
-					end
-					local cilvl = eItem:GetCurrentItemLevel()
-					if addon.itemBagFilters["minLevel"] and (cilvl < addon.itemBagFilters["minLevel"] or (nil == itemEquipLoc or addon.variables.ignoredEquipmentTypes[itemEquipLoc])) then
-						setVisibility = true
-					end
-					if addon.itemBagFilters["maxLevel"] and (cilvl > addon.itemBagFilters["maxLevel"] or (nil == itemEquipLoc or addon.variables.ignoredEquipmentTypes[itemEquipLoc])) then
-						setVisibility = true
-					end
-					if addon.itemBagFilters["currentExpension"] and LE_EXPANSION_LEVEL_CURRENT ~= expId then setVisibility = true end
-					if addon.itemBagFilters["equipment"] and (nil == itemEquipLoc or addon.variables.ignoredEquipmentTypes[itemEquipLoc]) then setVisibility = true end
-					if addon.itemBagFilters["bind"] then
-						if nil == addon.itemBagFiltersBound[bKey] or addon.itemBagFiltersBound[bKey] == false then setVisibility = true end
-					end
-					if addon.itemBagFilters["misc_auctionhouse_sellable"] then
-						if bAuc then setVisibility = true end
-					end
-					if addon.itemBagFilters["upgrade"] then
-						if nil == addon.itemBagFiltersUpgrade[upgradeKey] or addon.itemBagFiltersUpgrade[upgradeKey] == false then setVisibility = true end
-					end
-					if addon.itemBagFilters["misc_sellable"] then
-						if addon.itemBagFilters["misc_sellable"] == true and (not sellPrice or sellPrice == 0) then setVisibility = true end
-					end
-					if
-						addon.itemBagFilters["usableOnly"]
-						and (
-							IsEquippableItem(eItem:GetItemLink()) == false
-							or (
-								(
-									nil == addon.itemBagFilterTypes[addon.variables.unitClass]
-									or nil == addon.itemBagFilterTypes[addon.variables.unitClass][addon.variables.unitSpec]
-									or nil == addon.itemBagFilterTypes[addon.variables.unitClass][addon.variables.unitSpec][classID]
-									or nil == addon.itemBagFilterTypes[addon.variables.unitClass][addon.variables.unitSpec][classID][subclassID]
-									or itemEquipLoc == "INVTYPE_TABARD" -- ignore Tabards
-								) and itemEquipLoc ~= "INVTYPE_CLOAK" -- ignore Cloaks
-							)
+		local bType, bKey, upgradeKey, bAuc
+		local data
+		if addon.db["showBindOnBagItems"] or addon.itemBagFilters["bind"] or addon.itemBagFilters["upgrade"] or addon.itemBagFilters["misc_auctionhouse_sellable"] then
+			bType, bKey, upgradeKey, bAuc = getTooltipInfo(bag, slot)
+		end
+		local setVisibility = false
+
+		if addon.filterFrame then
+			if classID == 15 and subclassID == 0 then bAuc = true end -- ignore lockboxes etc.
+			if not itemButton.matchesSearch then setVisibility = true end
+			if addon.filterFrame:IsVisible() then
+				if addon.itemBagFilters["rarity"] then
+					if nil == addon.itemBagFiltersQuality[itemQuality] or addon.itemBagFiltersQuality[itemQuality] == false then setVisibility = true end
+				end
+				local cilvl = C_Item.GetDetailedItemLevelInfo(itemLink)
+				if addon.itemBagFilters["minLevel"] and (cilvl < addon.itemBagFilters["minLevel"] or (nil == itemEquipLoc or addon.variables.ignoredEquipmentTypes[itemEquipLoc])) then
+					setVisibility = true
+				end
+				if addon.itemBagFilters["maxLevel"] and (cilvl > addon.itemBagFilters["maxLevel"] or (nil == itemEquipLoc or addon.variables.ignoredEquipmentTypes[itemEquipLoc])) then
+					setVisibility = true
+				end
+				if addon.itemBagFilters["currentExpension"] and LE_EXPANSION_LEVEL_CURRENT ~= expId then setVisibility = true end
+				if addon.itemBagFilters["equipment"] and (nil == itemEquipLoc or addon.variables.ignoredEquipmentTypes[itemEquipLoc]) then setVisibility = true end
+				if addon.itemBagFilters["bind"] then
+					if nil == addon.itemBagFiltersBound[bKey] or addon.itemBagFiltersBound[bKey] == false then setVisibility = true end
+				end
+				if addon.itemBagFilters["misc_auctionhouse_sellable"] then
+					if bAuc then setVisibility = true end
+				end
+				if addon.itemBagFilters["upgrade"] then
+					if nil == addon.itemBagFiltersUpgrade[upgradeKey] or addon.itemBagFiltersUpgrade[upgradeKey] == false then setVisibility = true end
+				end
+				if addon.itemBagFilters["misc_sellable"] then
+					if addon.itemBagFilters["misc_sellable"] == true and (not sellPrice or sellPrice == 0) then setVisibility = true end
+				end
+				if
+					addon.itemBagFilters["usableOnly"]
+					and (
+						IsEquippableItem(itemLink) == false
+						or (
+							(
+								nil == addon.itemBagFilterTypes[addon.variables.unitClass]
+								or nil == addon.itemBagFilterTypes[addon.variables.unitClass][addon.variables.unitSpec]
+								or nil == addon.itemBagFilterTypes[addon.variables.unitClass][addon.variables.unitSpec][classID]
+								or nil == addon.itemBagFilterTypes[addon.variables.unitClass][addon.variables.unitSpec][classID][subclassID]
+								or itemEquipLoc == "INVTYPE_TABARD" -- ignore Tabards
+							) and itemEquipLoc ~= "INVTYPE_CLOAK" -- ignore Cloaks
 						)
-					then
-						setVisibility = true
+					)
+				then
+					setVisibility = true
+				end
+			end
+		end
+
+		if
+			(itemEquipLoc ~= "INVTYPE_NON_EQUIP_IGNORE" or (classID == 4 and subclassID == 0)) and not (classID == 4 and subclassID == 5) -- Cosmetic
+		then
+			if not itemButton.OverlayFilter then itemButton.OverlayFilter = itemButton:CreateFontString(nil, "ARTWORK") end
+			if not itemButton.ItemLevelText then
+				-- Create behind Blizzard's search overlay so it fades automatically
+				itemButton.ItemLevelText = itemButton:CreateFontString(nil, "ARTWORK")
+				itemButton.ItemLevelText:SetDrawLayer("ARTWORK", 1)
+				itemButton.ItemLevelText:SetFont(addon.variables.defaultFont, 13, "OUTLINE")
+				itemButton.ItemLevelText:SetPoint("TOPRIGHT", itemButton, "TOPRIGHT", 0, -2)
+
+				itemButton.ItemLevelText:SetShadowOffset(2, -2)
+				itemButton.ItemLevelText:SetShadowColor(0, 0, 0, 1)
+			end
+			if frameName then table.insert(knownButtons[frameName], itemButton) end
+			if nil ~= addon.variables.allowedEquipSlotsBagIlvl[itemEquipLoc] then
+				-- local color = eItem:GetItemQualityColor()
+				local r, g, b = C_Item.GetItemQualityColor(itemQuality)
+				local color = {
+					r = r,
+					g = g,
+					b = b,
+				}
+				local itemLevelText = C_Item.GetDetailedItemLevelInfo(itemLink)
+
+				itemButton.ItemLevelText:SetFormattedText(itemLevelText)
+				itemButton.ItemLevelText:SetTextColor(color.r, color.g, color.b, 1)
+
+				itemButton.ItemLevelText:Show()
+
+				if addon.db["showBindOnBagItems"] and bType then
+					if not itemButton.ItemBoundType then
+						-- Position behind Blizzard's overlay
+						itemButton.ItemBoundType = itemButton:CreateFontString(nil, "ARTWORK")
+						itemButton.ItemBoundType:SetDrawLayer("ARTWORK", 1)
+						itemButton.ItemBoundType:SetFont(addon.variables.defaultFont, 10, "OUTLINE")
+						itemButton.ItemBoundType:SetPoint("BOTTOMLEFT", itemButton, "BOTTOMLEFT", 2, 2)
+
+						itemButton.ItemBoundType:SetShadowOffset(2, 2)
+						itemButton.ItemBoundType:SetShadowColor(0, 0, 0, 1)
 					end
+					itemButton.ItemBoundType:SetFormattedText(bType)
+					itemButton.ItemBoundType:Show()
+				elseif itemButton.ItemBoundType then
+					itemButton.ItemBoundType:Hide()
 				end
+			elseif itemButton.ItemLevelText then
+				if itemButton.ItemBoundType then itemButton.ItemBoundType:Hide() end
+				itemButton.ItemLevelText:Hide()
+			end
+		end
+		-- itemButton:SetMatchesSearch(not setVisibility)
+		if setVisibility then
+			itemButton:SetAlpha(0.1)
+			if itemButton.ItemContextOverlay then
+				itemButton.ItemContextOverlay:Show()
+				itemButton.ItemContextOverlay:SetColorTexture(0, 0, 0, 0.8)
 			end
 
-			if
-				(itemEquipLoc ~= "INVTYPE_NON_EQUIP_IGNORE" or (classID == 4 and subclassID == 0)) and not (classID == 4 and subclassID == 5) -- Cosmetic
-			then
-				if not itemButton.OverlayFilter then itemButton.OverlayFilter = itemButton:CreateFontString(nil, "ARTWORK") end
-				if not itemButton.ItemLevelText then
-					-- Create behind Blizzard's search overlay so it fades automatically
-					itemButton.ItemLevelText = itemButton:CreateFontString(nil, "ARTWORK")
-					itemButton.ItemLevelText:SetDrawLayer("ARTWORK", 1)
-					itemButton.ItemLevelText:SetFont(addon.variables.defaultFont, 13, "OUTLINE")
-					itemButton.ItemLevelText:SetPoint("TOPRIGHT", itemButton, "TOPRIGHT", 0, -2)
-
-					itemButton.ItemLevelText:SetShadowOffset(2, -2)
-					itemButton.ItemLevelText:SetShadowColor(0, 0, 0, 1)
-				end
-				if frameName then table.insert(knownButtons[frameName], itemButton) end
-				local link = eItem:GetItemLink()
-				local invSlot = select(4, GetItemInfoInstant(link))
-				if nil ~= addon.variables.allowedEquipSlotsBagIlvl[invSlot] then
-					local color = eItem:GetItemQualityColor()
-					local itemLevelText = eItem:GetCurrentItemLevel()
-
-					itemButton.ItemLevelText:SetFormattedText(itemLevelText)
-					itemButton.ItemLevelText:SetTextColor(color.r, color.g, color.b, 1)
-
-					itemButton.ItemLevelText:Show()
-
-					if addon.db["showBindOnBagItems"] and bType then
-						if not itemButton.ItemBoundType then
-							-- Position behind Blizzard's overlay
-							itemButton.ItemBoundType = itemButton:CreateFontString(nil, "ARTWORK")
-							itemButton.ItemBoundType:SetDrawLayer("ARTWORK", 1)
-							itemButton.ItemBoundType:SetFont(addon.variables.defaultFont, 10, "OUTLINE")
-							itemButton.ItemBoundType:SetPoint("BOTTOMLEFT", itemButton, "BOTTOMLEFT", 2, 2)
-
-							itemButton.ItemBoundType:SetShadowOffset(2, 2)
-							itemButton.ItemBoundType:SetShadowColor(0, 0, 0, 1)
-						end
-						itemButton.ItemBoundType:SetFormattedText(bType)
-						itemButton.ItemBoundType:Show()
-					elseif itemButton.ItemBoundType then
-						itemButton.ItemBoundType:Hide()
-					end
-				elseif itemButton.ItemLevelText then
-					if itemButton.ItemBoundType then itemButton.ItemBoundType:Hide() end
-					itemButton.ItemLevelText:Hide()
-				end
-			end
-			-- itemButton:SetMatchesSearch(not setVisibility)
-			if setVisibility then
-				itemButton:SetAlpha(0.1)
-				if itemButton.ItemContextOverlay then
-					itemButton.ItemContextOverlay:Show()
-					itemButton.ItemContextOverlay:SetColorTexture(0, 0, 0, 0.8)
-				end
-
-				if itemButton.ItemLevelText then itemButton.ItemLevelText:SetAlpha(0.1) end
-				if itemButton.ItemBoundType then itemButton.ItemBoundType:SetAlpha(0.1) end
-				if itemButton.ProfessionQualityOverlay and addon.db["fadeBagQualityIcons"] then itemButton.ProfessionQualityOverlay:SetAlpha(0.1) end
-			else
-				itemButton:SetAlpha(1)
-				if itemButton.ItemContextOverlay then itemButton.ItemContextOverlay:Hide() end
-				if itemButton.ItemLevelText then itemButton.ItemLevelText:SetAlpha(1) end
-				if itemButton.ItemBoundType then itemButton.ItemBoundType:SetAlpha(1) end
-				if itemButton.ProfessionQualityOverlay and addon.db["fadeBagQualityIcons"] then itemButton.ProfessionQualityOverlay:SetAlpha(1) end
-			end
-		end)
+			if itemButton.ItemLevelText then itemButton.ItemLevelText:SetAlpha(0.1) end
+			if itemButton.ItemBoundType then itemButton.ItemBoundType:SetAlpha(0.1) end
+			if itemButton.ProfessionQualityOverlay and addon.db["fadeBagQualityIcons"] then itemButton.ProfessionQualityOverlay:SetAlpha(0.1) end
+		else
+			itemButton:SetAlpha(1)
+			if itemButton.ItemContextOverlay then itemButton.ItemContextOverlay:Hide() end
+			if itemButton.ItemLevelText then itemButton.ItemLevelText:SetAlpha(1) end
+			if itemButton.ItemBoundType then itemButton.ItemBoundType:SetAlpha(1) end
+			if itemButton.ProfessionQualityOverlay and addon.db["fadeBagQualityIcons"] then itemButton.ProfessionQualityOverlay:SetAlpha(1) end
+		end
+		-- end)
 	elseif itemButton.ItemLevelText then
 		if itemButton.ItemBoundType then itemButton.ItemBoundType:Hide() end
 		itemButton.ItemLevelText:Hide()

--- a/EnhanceQoLVendor/EnhanceQoLVendor.lua
+++ b/EnhanceQoLVendor/EnhanceQoLVendor.lua
@@ -237,6 +237,9 @@ local eventHandlers = {
 			updateLegend(value, addon.db["vendor" .. value .. "MinIlvlDif"])
 		end
 	end,
+	["INVENTORY_SEARCH_UPDATE"] = function()
+		C_Timer.After(0, function() updateSellMarks() end)
+	end,
 }
 local function registerEvents(frame)
 	for event in pairs(eventHandlers) do
@@ -509,7 +512,7 @@ local function addGeneralFrame(container)
 	local groupMark = addon.functions.createContainer("InlineGroup", "List")
 	wrapper:AddChild(groupMark)
 
-	local data = {
+	data = {
 		{
 			text = L["vendorShowSellOverlay"],
 			var = "vendorShowSellOverlay",
@@ -648,6 +651,13 @@ function updateSellMarks()
 						itemButton.SellOverlay:Show()
 					else
 						itemButton.SellOverlay:Hide()
+					end
+					if not itemButton.matchesSearch then
+						itemButton.ItemMarkSell:SetAlpha(0.1)
+						itemButton.SellOverlay:Hide()
+					else
+						if addon.db["vendorShowSellHighContrast"] then itemButton.SellOverlay:Show() end
+						itemButton.ItemMarkSell:SetAlpha(1)
 					end
 				elseif itemButton.ItemMarkSell then
 					itemButton.ItemMarkSell:Hide()

--- a/EnhanceQoLVendor/EnhanceQoLVendor.lua
+++ b/EnhanceQoLVendor/EnhanceQoLVendor.lua
@@ -125,7 +125,8 @@ local function lookupItems()
 		for slot = 1, C_Container.GetContainerNumSlots(bag) do
 			local itemID = C_Container.GetContainerItemID(bag, slot)
 			if itemID then
-				local itemName, itemLink, quality, itemLevel, _, _, _, _, _, _, sellPrice, classID, subclassID, bindType, expansionID = C_Item.GetItemInfo(itemID)
+				local itemLink = C_Container.GetContainerItemLink(bag, slot)
+				local itemName, _, quality, itemLevel, _, _, _, _, _, _, sellPrice, classID, subclassID, bindType, expansionID = C_Item.GetItemInfo(itemLink)
 				if not itemName then
 					C_Item.RequestLoadItemDataByID(itemID)
 				else

--- a/EnhanceQoLVendor/EnhanceQoLVendor.lua
+++ b/EnhanceQoLVendor/EnhanceQoLVendor.lua
@@ -13,6 +13,7 @@ local sellMoreButton
 local hasMoreItems = false
 local sellMarkLookup = {}
 local updateSellMarks
+local tooltipCache = {}
 
 local function inventoryOpen()
 	if ContainerFrameCombinedBags:IsShown() then return true end
@@ -71,97 +72,93 @@ local function sellItems(items)
 	sellNextItem()
 end
 
+local function getTooltipInfo(bag, slot, quality)
+	local key = bag .. "_" .. slot
+	local cached = tooltipCache[key]
+	if cached then return cached[1], cached[2], cached[3] end
+
+	local bType
+	local canUpgrade = false
+	local isIgnoredUpgradeTrack = false
+	local data = C_TooltipInfo.GetBagItem(bag, slot)
+	if data then
+		for _, v in pairs(data.lines) do
+			if v.type == 20 then
+				if v.leftText == ITEM_BIND_ON_EQUIP then
+					bType = 2
+				elseif v.leftText == ITEM_ACCOUNTBOUND_UNTIL_EQUIP or v.leftText == ITEM_BIND_TO_ACCOUNT_UNTIL_EQUIP then
+					bType = 8
+				elseif v.leftText == ITEM_ACCOUNTBOUND or v.leftText == ITEM_BIND_TO_BNETACCOUNT then
+					bType = 7
+				end
+				break
+			elseif v.type == 42 then
+				local text = v.rightText or v.leftText
+				if text then
+					if addon.db["vendor" .. addon.Vendor.variables.tabNames[quality] .. "IgnoreUpgradable"] then
+						local color = v.leftColor
+						if color and color.r and color.g and color.b then
+							if not (color.r > 0.5 and color.g > 0.5 and color.b > 0.5) then canUpgrade = true end
+						end
+					end
+					local tier = text:gsub(".+:%s?", ""):gsub("%s?%d/%d", "")
+					if tier then
+						if
+							(addon.db["vendor" .. addon.Vendor.variables.tabNames[quality] .. "IgnoreMythTrack"] and string.lower(L["upgradeLevelMythic"]) == string.lower(tier))
+							or (addon.db["vendor" .. addon.Vendor.variables.tabNames[quality] .. "IgnoreHeroicTrack"] and string.lower(L["upgradeLevelHero"]) == string.lower(tier))
+						then
+							isIgnoredUpgradeTrack = true
+						end
+					end
+				end
+			end
+		end
+	end
+
+	tooltipCache[key] = { bType, canUpgrade, isIgnoredUpgradeTrack }
+	return bType, canUpgrade, isIgnoredUpgradeTrack
+end
 local function lookupItems()
 	local _, avgItemLevelEquipped = GetAverageItemLevel()
 	local itemsToSell = {}
 	for bag = 0, NUM_TOTAL_EQUIPPED_BAG_SLOTS do
 		for slot = 1, C_Container.GetContainerNumSlots(bag) do
-			local containerInfo = C_Container.GetContainerItemInfo(bag, slot)
-			if containerInfo then
-				-- check if cosmetic
-				local eItem = Item:CreateFromBagAndSlot(bag, slot)
-				if eItem and not eItem:IsItemEmpty() then
-					eItem:ContinueOnItemLoad(function()
-						local link = eItem:GetItemLink()
-						local itemName, itemLink, _, itemLevel, _, _, _, _, _, _, sellPrice, classID, subclassID, bindType, expansionID = C_Item.GetItemInfo(link)
-
-						if sellPrice and sellPrice > 0 then
-							if classID == 4 and subclassID == 5 and not C_TransmogCollection.PlayerHasTransmog(containerInfo.itemID) then
-							-- Transmog not used don't sell
-							elseif addon.db["vendorExcludeSellList"][containerInfo.itemID] then -- ignore everything and exclude in sell
-							-- do nothing
-							elseif addon.db["vendorIncludeSellList"][containerInfo.itemID] then -- ignore everything and include in sell
-								if sellPrice > 0 then table.insert(itemsToSell, { bag = bag, slot = slot }) end
-							elseif classID == 7 and addon.Vendor.variables.itemQualityFilter[containerInfo.quality] then
-								local expTable = addon.db["vendor" .. addon.Vendor.variables.tabNames[containerInfo.quality] .. "CraftingExpansions"]
-								if expTable and expTable[expansionID] then table.insert(itemsToSell, { bag = bag, slot = slot }) end
-							elseif addon.Vendor.variables.itemQualityFilter[containerInfo.quality] then
-								local effectiveILvl = C_Item.GetDetailedItemLevelInfo(link) -- item level of the item with all upgrades calculated
-								-- local effectiveILvl = itemLevel -- item level of the item with all upgrades calculated
-
-								local bType = nil
-								local canUpgrade = false
-								local isIgnoredUpgradeTrack = false
-								local data = C_TooltipInfo.GetBagItem(bag, slot)
-								if nil ~= data then
-									for i, v in pairs(data.lines) do
-										if v.type == 20 then
-											if v.leftText == ITEM_BIND_ON_EQUIP then
-												bType = 2
-											elseif v.leftText == ITEM_ACCOUNTBOUND_UNTIL_EQUIP or v.leftText == ITEM_BIND_TO_ACCOUNT_UNTIL_EQUIP then
-												bType = 8
-											elseif v.leftText == ITEM_ACCOUNTBOUND or v.leftText == ITEM_BIND_TO_BNETACCOUNT then
-												bType = 7
-											end
-											break
-										elseif v.type == 42 then
-											local text = v.rightText or v.leftText
-											if text then
-												if addon.db["vendor" .. addon.Vendor.variables.tabNames[containerInfo.quality] .. "IgnoreUpgradable"] then
-													local color = v.leftColor
-													if color and color.r and color.g and color.b then
-														if not (color.r > 0.5 and color.g > 0.5 and color.b > 0.5) then -- gray upgrade text = old item upgradable --> not = ignore gray
-															canUpgrade = true
-														end
-													end
-												end
-												local tier = text:gsub(".+:%s?", ""):gsub("%s?%d/%d", "")
-												if tier then
-													if
-														(
-															addon.db["vendor" .. addon.Vendor.variables.tabNames[containerInfo.quality] .. "IgnoreMythTrack"]
-															and string.lower(L["upgradeLevelMythic"]) == string.lower(tier)
-														)
-														or (
-															addon.db["vendor" .. addon.Vendor.variables.tabNames[containerInfo.quality] .. "IgnoreHeroicTrack"]
-															and string.lower(L["upgradeLevelHero"]) == string.lower(tier)
-														)
-													then
-														isIgnoredUpgradeTrack = true
-													end
-												end
-											end
-										end
+			local itemID = C_Container.GetContainerItemID(bag, slot)
+			if itemID then
+				local itemName, itemLink, quality, itemLevel, _, _, _, _, _, _, sellPrice, classID, subclassID, bindType, expansionID = C_Item.GetItemInfo(itemID)
+				if not itemName then
+					C_Item.RequestLoadItemDataByID(itemID)
+				else
+					if sellPrice and sellPrice > 0 then
+						if classID == 4 and subclassID == 5 and not C_TransmogCollection.PlayerHasTransmog(itemID) then
+						-- Transmog not used don't sell
+						elseif addon.db["vendorExcludeSellList"][itemID] then
+						-- do nothing
+						elseif addon.db["vendorIncludeSellList"][itemID] then
+							if sellPrice > 0 then table.insert(itemsToSell, { bag = bag, slot = slot }) end
+						elseif classID == 7 and addon.Vendor.variables.itemQualityFilter[quality] then
+							local expTable = addon.db["vendor" .. addon.Vendor.variables.tabNames[quality] .. "CraftingExpansions"]
+							if expTable and expTable[expansionID] then table.insert(itemsToSell, { bag = bag, slot = slot }) end
+						elseif addon.Vendor.variables.itemQualityFilter[quality] then
+							local effectiveILvl = C_Item.GetDetailedItemLevelInfo(itemLink)
+							local bType, canUpgrade, isIgnoredUpgradeTrack = getTooltipInfo(bag, slot, quality)
+							if bType and bindType < bType then bindType = bType end
+							if not bType then bindType = 0 end
+							if
+								addon.Vendor.variables.itemTypeFilter[classID]
+								and (not addon.Vendor.variables.itemSubTypeFilter[classID] or (addon.Vendor.variables.itemSubTypeFilter[classID] and addon.Vendor.variables.itemSubTypeFilter[classID][subclassID]))
+								and addon.Vendor.variables.itemBindTypeQualityFilter[quality][bindType]
+							then
+								if not canUpgrade and not isIgnoredUpgradeTrack then
+									local rIlvl = (avgItemLevelEquipped - addon.db["vendor" .. addon.Vendor.variables.tabNames[quality] .. "MinIlvlDif"])
+									if addon.db["vendor" .. addon.Vendor.variables.tabNames[quality] .. "AbsolutIlvl"] then
+										rIlvl = addon.db["vendor" .. addon.Vendor.variables.tabNames[quality] .. "MinIlvlDif"]
 									end
-								end
-								if nil ~= bType and bindType < bType then bindType = bType end
-								if nil == bType then bindType = 0 end
-								if
-									addon.Vendor.variables.itemTypeFilter[classID]
-									and (not addon.Vendor.variables.itemSubTypeFilter[classID] or (addon.Vendor.variables.itemSubTypeFilter[classID] and addon.Vendor.variables.itemSubTypeFilter[classID][subclassID]))
-									and addon.Vendor.variables.itemBindTypeQualityFilter[containerInfo.quality][bindType]
-								then -- Check if classID is allowed for AutoSell
-									if not canUpgrade and not isIgnoredUpgradeTrack then
-										local rIlvl = (avgItemLevelEquipped - addon.db["vendor" .. addon.Vendor.variables.tabNames[containerInfo.quality] .. "MinIlvlDif"])
-										if addon.db["vendor" .. addon.Vendor.variables.tabNames[containerInfo.quality] .. "AbsolutIlvl"] then
-											rIlvl = addon.db["vendor" .. addon.Vendor.variables.tabNames[containerInfo.quality] .. "MinIlvlDif"]
-										end
-										if effectiveILvl <= rIlvl then table.insert(itemsToSell, { bag = bag, slot = slot }) end
-									end
+									if effectiveILvl <= rIlvl then table.insert(itemsToSell, { bag = bag, slot = slot }) end
 								end
 							end
 						end
-					end)
+					end
 				end
 			end
 		end
@@ -214,7 +211,9 @@ local eventHandlers = {
 	["MERCHANT_CLOSED"] = function()
 		hasMoreItems = false
 		updateSellMoreButton()
+		wipe(tooltipCache)
 	end,
+	["BAG_UPDATE_DELAYED"] = function() wipe(tooltipCache) end,
 	["ITEM_DATA_LOAD_RESULT"] = function(arg1, arg2)
 		if arg2 == false and addon.aceFrame:IsShown() and lastEbox then
 			StaticPopupDialogs["VendorWrongItemID"] = {


### PR DESCRIPTION
## Summary
- add tooltip cache and BAG_UPDATE delay wipe
- switch to `GetContainerItemID` and caching in `lookupItems`
- add helper `getTooltipInfo` for tooltip parsing

## Testing
- `stylua EnhanceQoLVendor/EnhanceQoLVendor.lua`
- `luacheck EnhanceQoLVendor/EnhanceQoLVendor.lua` *(warns: variable data previously defined)*

------
https://chatgpt.com/codex/tasks/task_e_688085d109c48329bd69b555246a236e