### PR TITLE
Document mapID return from Challenge Mode API

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,3 +28,17 @@ These global functions are deprecated in 11.2 and should be replaced once suppor
 - `SendChatMessage` -> `C_ChatInfo.SendChatMessage`
 - `EquipmentManager_UnpackLocation` will change in 12.0 when Void Storage is removed
 - Translation key `L["Reagentbank"]` will no longer be needed
+
+### Challenge Mode Map IDs
+
+`C_ChallengeMode.GetMapUIInfo()` now returns `mapID` as its sixth result.
+Static lookup tables for `mapID` should be removed once support for
+pre-11.2 versions is dropped.
+
+Affected files:
+- `EnhanceQoLMythicPlus/Init.lua` (portalCompendium entries)
+- `EnhanceQoLMythicPlus/DungeonPortal.lua` (`mapIDInfo` table)
+- `EnhanceQoLMythicPlus/TalentReminder.lua` (`seasonMapInfo` creation)
+
+After the patch, refactor these modules to read the new `mapID` return
+instead of maintaining `mapIDInfo`.


### PR DESCRIPTION
## Summary
- note new `mapID` return from `C_ChallengeMode.GetMapUIInfo()` in TODO
- list modules that will need refactoring after dropping pre-11.2 support

## Testing
- `luacheck --no-color -q .`

------
https://chatgpt.com/codex/tasks/task_e_68827800d6a08329adc70d0c63533b78