### PR TITLE
Fix unit frame truncation on solo join

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -3293,8 +3293,18 @@ local function initUnitFrame()
 	local function TruncateFrameName(cuf)
 		if not addon.db["unitFrameTruncateNames"] then return end
 		if not addon.db["unitFrameMaxNameLength"] then return end
-		if cuf and cuf.name and type(cuf.name.GetText) == "function" and type(cuf.name.SetText) == "function" and cuf.name:GetText() then
-			local name = cuf.name:GetText()
+		if not cuf then return end
+
+		local name
+		if cuf.unit and UnitExists(cuf.unit) then
+			name = UnitName(cuf.unit)
+		elseif cuf.displayedUnit and UnitExists(cuf.displayedUnit) then
+			name = UnitName(cuf.displayedUnit)
+		elseif cuf.name and type(cuf.name.GetText) == "function" then
+			name = cuf.name:GetText()
+		end
+
+		if name and cuf.name and type(cuf.name.SetText) == "function" then
 			-- Remove server names before truncation
 			local shortName = strsplit("-", name)
 			if #shortName > addon.db["unitFrameMaxNameLength"] then shortName = strsub(shortName, 1, addon.db["unitFrameMaxNameLength"]) end


### PR DESCRIPTION
## Summary
- avoid calling GetText on missing frame by fetching the name via `UnitName` when possible
- keep truncated party frame names up to date

## Testing
- `luacheck EnhanceQoL/EnhanceQoL.lua`

------
https://chatgpt.com/codex/tasks/task_e_6884d43b406c8329b868a78450913e53