### PR TITLE
Add alternative spell ID tracking for Cast Tracker

### DIFF
--- a/EnhanceQoLAura/Init.lua
+++ b/EnhanceQoLAura/Init.lua
@@ -125,10 +125,17 @@ for id, cat in pairs(addon.db["castTrackerCategories"] or {}) do
 	cat.color = cat.color or { 1, 0.5, 0, 1 }
 	if cat.duration == nil then cat.duration = 0 end
 	if cat.sound == nil then cat.sound = SOUNDKIT.ALARM_CLOCK_WARNING_3 end
-	cat.spells = cat.spells or {}
-	if addon.db["castTrackerEnabled"][id] == nil then addon.db["castTrackerEnabled"][id] = true end
-	if addon.db["castTrackerLocked"][id] == nil then addon.db["castTrackerLocked"][id] = false end
-	addon.db["castTrackerOrder"][id] = addon.db["castTrackerOrder"][id] or {}
+        cat.spells = cat.spells or {}
+        for sid, spell in pairs(cat.spells) do
+                if type(spell) ~= "table" then
+                        cat.spells[sid] = { altIDs = {} }
+                else
+                        spell.altIDs = spell.altIDs or {}
+                end
+        end
+        if addon.db["castTrackerEnabled"][id] == nil then addon.db["castTrackerEnabled"][id] = true end
+        if addon.db["castTrackerLocked"][id] == nil then addon.db["castTrackerLocked"][id] = false end
+        addon.db["castTrackerOrder"][id] = addon.db["castTrackerOrder"][id] or {}
 end
 
 if type(addon.db["castTrackerSelectedCategory"]) ~= "number" then addon.db["castTrackerSelectedCategory"] = 1 end


### PR DESCRIPTION
## Summary
- store alt spell IDs for cast tracker spells
- allow editing alternative spell IDs in cast tracker options
- resolve alt spell IDs in combat log events

## Testing
- `luacheck EnhanceQoLAura/CastTracker.lua EnhanceQoLAura/Init.lua`
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_68853a07ce348329ad5aecdf28fdb6fd