### PR TITLE
Fix default spell label in CastTracker options

### DIFF
--- a/EnhanceQoLAura/CastTracker.lua
+++ b/EnhanceQoLAura/CastTracker.lua
@@ -659,7 +659,7 @@ local function buildSpellOptions(container, catId, spellId)
 
 	local info = C_Spell.GetSpellInfo(spellId)
 	local name = info and info.name or tostring(spellId)
-	local labelName = spell.treeName or name
+    local labelName = (spell.treeName and spell.treeName ~= "" and spell.treeName) or name
 	local label = addon.functions.createLabelAce(labelName .. " (" .. spellId .. ")")
 	wrapper:AddChild(label)
 


### PR DESCRIPTION
## Summary
- ensure spell name shows in CastTracker spell options when no custom tree name is set

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_68871efa0a6883299ecc64b475be1df1