### PR TITLE
Fix CastTracker bar removal on interrupts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.35.1] – 2025-07-29
+### 🐛 Fixed
+- **Cast Tracker**
+  - Bars now disappear reliably when casts are interrupted or cancelled.
+
 ## [3.35.0] – 2025-07-28
 ### ✨ Added
 - **Cast Tracker**


### PR DESCRIPTION
## Summary
- stop cast tracker bars when UNIT_SPELLCAST_STOP or UNIT_SPELLCAST_INTERRUPTED occur
- document fix in changelog

## Testing
- `luacheck EnhanceQoLAura/CastTracker.lua`
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_68875df52d4883299e0d8d9db4fbce46