### PR TITLE
Fix nil error when removing buff tracker category

### DIFF
--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -1090,8 +1090,26 @@ local function removeBuff(catId, id)
 		auraInstanceMap[buffInstances[instKey]] = nil
 		buffInstances[instKey] = nil
 	end
-	rebuildAltMapping()
-	scanBuffs()
+        rebuildAltMapping()
+        scanBuffs()
+end
+
+local function clearCategoryData(catId)
+	if activeBuffFrames[catId] then
+		for _, frame in pairs(activeBuffFrames[catId]) do
+			frame:Hide()
+		end
+		activeBuffFrames[catId] = nil
+	end
+	for key, info in pairs(timedAuras) do
+		if info.catId == catId then timedAuras[key] = nil end
+	end
+	for key, inst in pairs(buffInstances) do
+		if key:match("^" .. catId .. ":") then
+			auraInstanceMap[inst] = nil
+			buffInstances[key] = nil
+		end
+	end
 end
 
 local function sanitiseCategory(cat)
@@ -1430,21 +1448,23 @@ function addon.Aura.functions.buildCategoryOptions(container, catId)
 			for buffId in pairs(addon.db["buffTrackerCategories"][catId].buffs or {}) do
 				addon.db["buffTrackerHidden"][buffId] = nil
 			end
-			addon.db["buffTrackerCategories"][catId] = nil
-			addon.db["buffTrackerOrder"][catId] = nil
-			addon.db["buffTrackerSounds"][catId] = nil
-			addon.db["buffTrackerSoundsEnabled"][catId] = nil
-			addon.db["buffTrackerEnabled"][catId] = nil
-			addon.db["buffTrackerLocked"][catId] = nil
-			if anchors[catId] then
-				anchors[catId]:Hide()
-				anchors[catId] = nil
-			end
-			selectedCategory = next(addon.db["buffTrackerCategories"]) or 1
-			rebuildAltMapping()
-			refreshTree(selectedCategory)
-			container:ReleaseChildren()
-		end
+                       addon.db["buffTrackerCategories"][catId] = nil
+                       addon.db["buffTrackerOrder"][catId] = nil
+                       addon.db["buffTrackerSounds"][catId] = nil
+                       addon.db["buffTrackerSoundsEnabled"][catId] = nil
+                       addon.db["buffTrackerEnabled"][catId] = nil
+                       addon.db["buffTrackerLocked"][catId] = nil
+                       if anchors[catId] then
+                               anchors[catId]:Hide()
+                               anchors[catId] = nil
+                       end
+                       clearCategoryData(catId)
+                       selectedCategory = next(addon.db["buffTrackerCategories"]) or 1
+                       rebuildAltMapping()
+                       scanBuffs()
+                       refreshTree(selectedCategory)
+                       container:ReleaseChildren()
+               end
 		StaticPopup_Show("EQOL_DELETE_CATEGORY", catName)
 	end)
 	core:AddChild(delBtn)


### PR DESCRIPTION
## Summary
- avoid nil 'buff' when a buff category is deleted
- remove frames and aura references for the deleted category

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_6887b6c0bdfc8329bb79f270f7c570b2