### PR TITLE
Make Cast Tracker opt in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.35.1] – 2025-07-29
+### 🔄 Changed
+- Cast Tracker is now disabled by default. Enable it manually to opt in.
+
 ## [3.35.0] – 2025-07-28
 ### ✨ Added
 - **Cast Tracker**

--- a/EnhanceQoLAura/CastTracker.lua
+++ b/EnhanceQoLAura/CastTracker.lua
@@ -343,7 +343,7 @@ local function importCategory(encoded)
 	local newId = getNextCategoryId()
 	addon.db.castTrackerCategories[newId] = cat
 	addon.db.castTrackerOrder[newId] = data.order or {}
-	addon.db.castTrackerEnabled[newId] = true
+        addon.db.castTrackerEnabled[newId] = false
 	addon.db.castTrackerLocked[newId] = false
 	addon.db.castTrackerSounds[newId] = {}
 	addon.db.castTrackerSoundsEnabled[newId] = {}
@@ -1155,7 +1155,7 @@ function CastTracker.functions.addCastTrackerOptions(container)
 				spells = {},
 				allowedRoles = {},
 			}
-			addon.db.castTrackerEnabled[newId] = true
+                        addon.db.castTrackerEnabled[newId] = false
 			addon.db.castTrackerLocked[newId] = false
 			addon.db.castTrackerOrder[newId] = {}
 			ensureAnchor(newId)

--- a/EnhanceQoLAura/Init.lua
+++ b/EnhanceQoLAura/Init.lua
@@ -162,7 +162,7 @@ for id, cat in pairs(addon.db["castTrackerCategories"] or {}) do
 		if spell.customText == nil then spell.customText = "" end
 	end
 	cat.sound = nil
-	if addon.db["castTrackerEnabled"][id] == nil then addon.db["castTrackerEnabled"][id] = true end
+        if addon.db["castTrackerEnabled"][id] == nil then addon.db["castTrackerEnabled"][id] = false end
 	if addon.db["castTrackerLocked"][id] == nil then addon.db["castTrackerLocked"][id] = false end
 	addon.db["castTrackerOrder"][id] = addon.db["castTrackerOrder"][id] or {}
 end


### PR DESCRIPTION
## Summary
- disable Cast Tracker by default so new users must opt-in
- update changelog

## Testing
- `luacheck .`

------
https://chatgpt.com/codex/tasks/task_e_688889dee7688329bb1a36c340f80761