### PR TITLE
Fix cooldown notify anchor update

### DIFF
--- a/EnhanceQoLAura/CooldownNotify.lua
+++ b/EnhanceQoLAura/CooldownNotify.lua
@@ -235,13 +235,20 @@ end
 function applyAnchor(id)
 	local cat = addon.db.cooldownNotifyCategories[id]
 	if not cat then return end
-	local anchor = ensureAnchor(id)
-	anchor:ClearAllPoints()
-	anchor:SetPoint(cat.anchor.point, UIParent, cat.anchor.point, cat.anchor.x, cat.anchor.y)
-	if DCP:IsShown() and currentCatId == id then
-		DCP:ClearAllPoints()
-		DCP:SetPoint(cat.anchor.point or "CENTER", UIParent, cat.anchor.point or "CENTER", cat.anchor.x or 0, cat.anchor.y or 0)
-	end
+       local anchor = ensureAnchor(id)
+       anchor:ClearAllPoints()
+       anchor:SetPoint(cat.anchor.point, UIParent, cat.anchor.point, cat.anchor.x, cat.anchor.y)
+
+       if DCP:IsShown() then
+               if currentCatId == id then
+                       DCP:ClearAllPoints()
+                       DCP:SetPoint(cat.anchor.point or "CENTER", UIParent, cat.anchor.point or "CENTER", cat.anchor.x or 0, cat.anchor.y or 0)
+               end
+       else
+               -- Update the cooldown frame position so it spawns at the new anchor
+               DCP:ClearAllPoints()
+               DCP:SetPoint(cat.anchor.point or "CENTER", UIParent, cat.anchor.point or "CENTER", cat.anchor.x or 0, cat.anchor.y or 0)
+       end
 end
 
 function CN:SPELL_UPDATE_COOLDOWN(spellID)


### PR DESCRIPTION
## Summary
- ensure cooldown notification frame updates anchor even when not visible

## Testing
- `luacheck EnhanceQoLAura/CooldownNotify.lua`

------
https://chatgpt.com/codex/tasks/task_e_688a0e18fd7c8329be9daf0c7fee9d13