### PR TITLE
Fix chat import causing UI error

### DIFF
--- a/EnhanceQoLAura/CooldownNotify.lua
+++ b/EnhanceQoLAura/CooldownNotify.lua
@@ -810,8 +810,8 @@ local function HandleEQOLLink(link, text, button, frame)
 				local encoded = incoming[data]
 				incoming[data] = nil
 				pending[label] = nil
-				local newId = importCategory(encoded)
-				if newId and CN.functions.addCooldownNotifyOptions then CN.functions.addCooldownNotifyOptions(frame or UIParent) end
+                                local newId = importCategory(encoded)
+                                if newId then refreshTree(newId) end
 			end,
 		}
 	StaticPopupDialogs["EQOL_IMPORT_FROM_SHARE"].OnShow = function(self, data)


### PR DESCRIPTION
## Summary
- fix error when importing CooldownNotify categories via chat links

## Testing
- `luacheck EnhanceQoLAura/CooldownNotify.lua`


------
https://chatgpt.com/codex/tasks/task_e_688a3c3bf1a88329893f6996726542da