### PR TITLE
feat(sharedmedia): add options UI for shared sounds

### DIFF
--- a/EnhanceQoLSharedMedia/EnhanceQoLSharedMedia.toc
+++ b/EnhanceQoLSharedMedia/EnhanceQoLSharedMedia.toc
@@ -22,3 +22,4 @@
 
 EnhanceQoLSharedMedia.lua
 Init.lua
+UI.lua

--- a/EnhanceQoLSharedMedia/UI.lua
+++ b/EnhanceQoLSharedMedia/UI.lua
@@ -1,0 +1,41 @@
+local parentAddonName = "EnhanceQoL"
+local addonName, addon = ...
+if _G[parentAddonName] then
+	addon = _G[parentAddonName]
+else
+	error(parentAddonName .. " is not loaded")
+end
+
+addon.SharedMedia = addon.SharedMedia or {}
+addon.SharedMedia.functions = addon.SharedMedia.functions or {}
+
+local function addSoundFrame(container)
+	local scroll = addon.functions.createContainer("ScrollFrame", "Flow")
+	scroll:SetFullWidth(true)
+	scroll:SetFullHeight(true)
+	container:AddChild(scroll)
+
+	local wrapper = addon.functions.createContainer("SimpleGroup", "List")
+	wrapper:SetFullWidth(true)
+	scroll:AddChild(wrapper)
+
+	for _, sound in ipairs(addon.SharedMedia.sounds or {}) do
+		local row = addon.functions.createContainer("SimpleGroup", "Flow")
+		row:SetFullWidth(true)
+
+		local cb = addon.functions.createCheckboxAce(sound.label, addon.db.sharedMediaSounds[sound.key], function(self, _, value) addon.SharedMedia.functions.UpdateSound(sound.key, value) end)
+		cb:SetRelativeWidth(0.8)
+		row:AddChild(cb)
+
+		local btn = addon.functions.createButtonAce("Play", 80, function() PlaySoundFile(sound.path) end)
+		btn:SetRelativeWidth(0.2)
+		row:AddChild(btn)
+
+		wrapper:AddChild(row)
+	end
+end
+
+function addon.SharedMedia.functions.treeCallback(container, group)
+	container:ReleaseChildren()
+	addSoundFrame(container)
+end


### PR DESCRIPTION
## Summary
- add shared media options UI with scrollable sound list
- register new UI file in .toc

## Testing
- `stylua EnhanceQoLSharedMedia/UI.lua`
- `luac -p EnhanceQoLSharedMedia/UI.lua`
- `luac -p EnhanceQoLSharedMedia/EnhanceQoLSharedMedia.lua EnhanceQoLSharedMedia/Init.lua`


------
https://chatgpt.com/codex/tasks/task_e_688dce9ec8dc8329831e88042367bf30