### PR TITLE
feat(sharedmedia): integrate shared media node

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -4548,6 +4548,8 @@ local function CreateUI()
 			addon.Aura.functions.treeCallback(container, group)
 		elseif string.match(group, "^sound") then
 			addon.Sounds.functions.treeCallback(container, group)
+		elseif string.match(group, "^sharedmedia") then
+			addon.SharedMedia.functions.treeCallback(container, group)
 		elseif string.match(group, "^mouse") then
 			addon.Mouse.functions.treeCallback(container, group)
 		elseif string.match(group, "^move") then

--- a/EnhanceQoLSharedMedia/Init.lua
+++ b/EnhanceQoLSharedMedia/Init.lua
@@ -9,7 +9,11 @@ end
 addon.SharedMedia = addon.SharedMedia or {}
 addon.SharedMedia.functions = addon.SharedMedia.functions or {}
 
+local L = LibStub("AceLocale-3.0"):GetLocale("EnhanceQoL_SharedMedia")
 local LSM = LibStub("LibSharedMedia-3.0")
+
+addon.variables.statusTable.groups["sharedmedia"] = true
+addon.functions.addToTree(nil, { value = "sharedmedia", text = L["Shared Media"] })
 
 addon.functions.InitDBValue("sharedMediaSounds", {})
 


### PR DESCRIPTION
## Summary
- expose Shared Media options in the tree
- route Shared Media tree selections to its callback

## Testing
- `stylua EnhanceQoLSharedMedia/Init.lua EnhanceQoL/EnhanceQoL.lua`
- `luacheck EnhanceQoLSharedMedia/Init.lua EnhanceQoL/EnhanceQoL.lua EnhanceQoLSharedMedia/UI.lua`


------
https://chatgpt.com/codex/tasks/task_e_688de3a323dc832983a40784d08afb0e