### PR TITLE
Add auto-confirm options for enchant and socket popups

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -2345,6 +2345,27 @@ local function addMiscFrame(container, d)
 			desc = L["confirmTimerRemovalTradeDesc"],
 			callback = function(self, _, value) addon.db["confirmTimerRemovalTrade"] = value end,
 		},
+		{
+			parent = "",
+			var = "confirmReplaceEnchant",
+			type = "CheckBox",
+			desc = L["confirmReplaceEnchantDesc"],
+			callback = function(self, _, value) addon.db["confirmReplaceEnchant"] = value end,
+		},
+		{
+			parent = "",
+			var = "confirmSocketReplace",
+			type = "CheckBox",
+			desc = L["confirmSocketReplaceDesc"],
+			callback = function(self, _, value) addon.db["confirmSocketReplace"] = value end,
+		},
+		{
+			parent = "",
+			var = "confirmAddSocket",
+			type = "CheckBox",
+			desc = L["confirmAddSocketDesc"],
+			callback = function(self, _, value) addon.db["confirmAddSocket"] = value end,
+		},
 
 		{
 			parent = "",
@@ -3289,6 +3310,9 @@ local function initMisc()
 	addon.functions.InitDBValue("confirmTimerRemovalTrade", false)
 	addon.functions.InitDBValue("confirmPatronOrderDialog", false)
 	addon.functions.InitDBValue("deleteItemFillDialog", false)
+	addon.functions.InitDBValue("confirmReplaceEnchant", false)
+	addon.functions.InitDBValue("confirmSocketReplace", false)
+	addon.functions.InitDBValue("confirmAddSocket", false)
 	addon.functions.InitDBValue("hideRaidTools", false)
 	addon.functions.InitDBValue("autoRepair", false)
 	addon.functions.InitDBValue("sellAllJunk", false)
@@ -3321,6 +3345,12 @@ local function initMisc()
 						local order = C_CraftingOrders.GetClaimedOrder()
 						if order and order.npcCustomerCreatureID and order.npcCustomerCreatureID > 0 then self.button1:Click() end
 					elseif addon.db["confirmTimerRemovalTrade"] and self.which == "CONFIRM_MERCHANT_TRADE_TIMER_REMOVAL" and self.button1 then
+						self.button1:Click()
+					elseif addon.db["confirmReplaceEnchant"] and self.which == "REPLACE_ENCHANT" and self.button1 then
+						self.button1:Click()
+					elseif addon.db["confirmSocketReplace"] and self.which == "CONFIRM_ACCEPT_SOCKETS" and self.button1 then
+						self.button1:Click()
+					elseif addon.db["confirmAddSocket"] and self.which == "SPELL_CONFIRMATION_PROMPT" and self.button1 then
 						self.button1:Click()
 					end
 				end

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -82,6 +82,12 @@ L["confirmPatronOrderDialogDesc"] = "Skips the materials confirmation dialog whe
 L["autoChooseQuest"] = "Automatically accept and complete Quests"
 L["confirmTimerRemovalTrade"] = "Automatically confirm to sell tradeable loot within the trade window time frame"
 L["confirmTimerRemovalTradeDesc"] = "Confirms timer removal automatically when trading bound loot"
+L["confirmReplaceEnchant"] = "Automatically accept Enchant Replacement"
+L["confirmReplaceEnchantDesc"] = "Skips the confirmation dialog when replacing an enchant"
+L["confirmSocketReplace"] = "Automatically accept Socket replacement"
+L["confirmSocketReplaceDesc"] = "Skips the confirmation dialog when replacing sockets"
+L["confirmAddSocket"] = "Automatically accept adding sockets to your items"
+L["confirmAddSocketDesc"] = "Skips the confirmation dialog when adding sockets to items"
 
 L["General"] = "General"
 L["Character"] = "Character"


### PR DESCRIPTION
## Summary
- add settings to automatically confirm enchant replacements, socket replacements, and adding sockets
- hook static popup dialogs to click accept when enabled
- localize new options in enUS

## Testing
- `luacheck EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`
- `stylua EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`


------
https://chatgpt.com/codex/tasks/task_e_688e09227ad88329bddd5ce49c2e2a9a