### PR TITLE
Fix unnecessary buff sounds after loading screens

### DIFF
--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -876,7 +876,7 @@ function updateBuff(catId, id, changedId, firstScan)
 			frame.customText:Hide()
 		end
 		frame:Show()
-		if frame.isActive and not wasShown and frame:IsShown() then playBuffSound(catId, id) end
+		if frame.isActive and not wasShown and frame:IsShown() and not firstScan then playBuffSound(catId, id) end
 		buffInstances[key] = nil
 		return
 	end
@@ -945,7 +945,7 @@ function updateBuff(catId, id, changedId, firstScan)
 			end
 			frame.icon:SetDesaturated(false)
 			frame.icon:SetAlpha(1)
-			if not wasActive then playBuffSound(catId, id, triggeredId) end
+			if not wasActive and not firstScan then playBuffSound(catId, id, triggeredId) end
 			frame.isActive = true
 		else
 			frame.cd:SetReverse(false)
@@ -1017,7 +1017,7 @@ function updateBuff(catId, id, changedId, firstScan)
 				ActionButton_HideOverlayGlow(frame)
 			end
 			frame:Show()
-			if displayAura and not wasShown and frame:IsShown() then playBuffSound(catId, id, triggeredId) end
+			if displayAura and not wasShown and frame:IsShown() and not firstScan then playBuffSound(catId, id, triggeredId) end
 		else
 			local icon = buff.icon
 			-- TODO 11.2: Replace IsSpellKnown* usage with C_SpellBook.IsSpellInSpellBook
@@ -1067,7 +1067,7 @@ function updateBuff(catId, id, changedId, firstScan)
 				ActionButton_HideOverlayGlow(frame)
 			end
 			frame:Show()
-			if not wasShown and frame:IsShown() then playBuffSound(catId, id, triggeredId) end
+			if not wasShown and frame:IsShown() and not firstScan then playBuffSound(catId, id, triggeredId) end
 		end
 	else
 		if frame then


### PR DESCRIPTION
## Summary
- avoid playing buff tracker sounds during initial scan to stop false alerts after loading screens

## Testing
- `stylua EnhanceQoLAura/BuffTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_688f8fb86e988329a81b050626e011bc