### PR TITLE
Add Craft Shopper enable toggle

### DIFF
--- a/EnhanceQoLVendor/EnhanceQoLVendor.lua
+++ b/EnhanceQoLVendor/EnhanceQoLVendor.lua
@@ -283,9 +283,9 @@ local function addVendorFrame(container, type)
 			lIlvl = addon.Vendor.variables.avgItemLevelEquipped - sValue2
 		end
 
-                labelHeadlineExplain:SetText("|cffffd700" .. L["labelExplainedline"]:format(iqColor, lIlvl, table.concat(text, " " .. L["andWord"] .. " ")) .. "|r")
-                wrapper:DoLayout()
-                updateSellMarks(nil, true)
+		labelHeadlineExplain:SetText("|cffffd700" .. L["labelExplainedline"]:format(iqColor, lIlvl, table.concat(text, " " .. L["andWord"] .. " ")) .. "|r")
+		wrapper:DoLayout()
+		updateSellMarks(nil, true)
 	end
 
 	local groupCore = addon.functions.createContainer("InlineGroup", "List")
@@ -361,8 +361,8 @@ local function addVendorFrame(container, type)
 		end
 		local list, order = addon.functions.prepareListForDropdown(expList, true)
 		local dropCrafting = addon.functions.createDropdownAce(L["vendorCraftingExpansions"], list, order, function(self, event, key, checked)
-                        addon.db["vendor" .. value .. "CraftingExpansions"][key] = checked or nil
-                        updateSellMarks(nil, true)
+			addon.db["vendor" .. value .. "CraftingExpansions"][key] = checked or nil
+			updateSellMarks(nil, true)
 		end)
 		dropCrafting:SetMultiselect(true)
 		for id, val in pairs(addon.db["vendor" .. value .. "CraftingExpansions"]) do
@@ -387,7 +387,7 @@ local function addVendorFrame(container, type)
 		groupInfo:SetFullWidth(true)
 		labelHeadlineExplain:SetFullWidth(true)
 	end
-        updateSellMarks(nil, true)
+	updateSellMarks(nil, true)
 end
 
 local function addInExcludeFrame(container, type)
@@ -421,9 +421,9 @@ local function addInExcludeFrame(container, type)
 					addon.db[dbValue][eItem:GetItemID()] = eItem:GetItemName()
 					print(ADD .. ":", eItem:GetItemID(), eItem:GetItemName())
 					local list, order = addon.functions.prepareListForDropdown(addon.db[dbValue])
-                                        dropIncludeList:SetList(list, order)
-                                        dropIncludeList:SetValue(nil) -- Setze die Auswahl zurück
-                                        updateSellMarks(nil, true)
+					dropIncludeList:SetList(list, order)
+					dropIncludeList:SetValue(nil) -- Setze die Auswahl zurück
+					updateSellMarks(nil, true)
 				end
 				eBox:SetText("")
 			end)
@@ -459,9 +459,9 @@ local function addInExcludeFrame(container, type)
 				addon.db[dbValue][selectedValue] = nil -- Entferne aus der Datenbank
 				-- Aktualisiere die Dropdown-Liste
 				local list, order = addon.functions.prepareListForDropdown(addon.db[dbValue])
-                                dropIncludeList:SetList(list, order)
-                                dropIncludeList:SetValue(nil) -- Setze die Auswahl zurück
-                                updateSellMarks(nil, true)
+				dropIncludeList:SetList(list, order)
+				dropIncludeList:SetValue(nil) -- Setze die Auswahl zurück
+				updateSellMarks(nil, true)
 			end
 		end
 	end)
@@ -482,6 +482,18 @@ local function addGeneralFrame(container)
 	wrapper:AddChild(groupCore)
 
 	local data = {
+		{
+			text = L["vendorCraftShopperEnable"],
+			var = "vendorCraftShopperEnable",
+			func = function(self, _, checked)
+				addon.db["vendorCraftShopperEnable"] = checked
+				if checked then
+					addon.Vendor.CraftShopper.EnableCraftShopper()
+				else
+					addon.Vendor.CraftShopper.DisableCraftShopper()
+				end
+			end,
+		},
 		{ text = L["vendorSwapAutoSellShift"], var = "vendorSwapAutoSellShift" },
 		{
 			text = L["vendorOnly12Items"],
@@ -517,8 +529,8 @@ local function addGeneralFrame(container)
 			text = L["vendorShowSellOverlay"],
 			var = "vendorShowSellOverlay",
 			func = function(self, _, checked)
-                                addon.db["vendorShowSellOverlay"] = checked
-                                if inventoryOpen() then updateSellMarks(nil, true) end
+				addon.db["vendorShowSellOverlay"] = checked
+				if inventoryOpen() then updateSellMarks(nil, true) end
 				container:ReleaseChildren()
 				addGeneralFrame(container)
 			end,
@@ -527,8 +539,8 @@ local function addGeneralFrame(container)
 			text = L["vendorShowSellTooltip"],
 			var = "vendorShowSellTooltip",
 			func = function(self, _, checked)
-                                addon.db["vendorShowSellTooltip"] = checked
-                                if inventoryOpen() then updateSellMarks(nil, true) end
+				addon.db["vendorShowSellTooltip"] = checked
+				if inventoryOpen() then updateSellMarks(nil, true) end
 			end,
 		},
 	}
@@ -538,8 +550,8 @@ local function addGeneralFrame(container)
 			text = L["vendorShowSellHighContrast"],
 			var = "vendorShowSellHighContrast",
 			func = function(self, _, checked)
-                                addon.db["vendorShowSellHighContrast"] = checked
-                                if inventoryOpen() then updateSellMarks(nil, true) end
+				addon.db["vendorShowSellHighContrast"] = checked
+				if inventoryOpen() then updateSellMarks(nil, true) end
 			end,
 		})
 	end
@@ -595,10 +607,10 @@ function addon.Vendor.functions.treeCallback(container, group)
 end
 
 function updateSellMarks(_, resetCache)
-        if resetCache then wipe(tooltipCache) end
+	if resetCache then wipe(tooltipCache) end
 
-        local overlay = addon.db["vendorShowSellOverlay"]
-        local tooltip = addon.db["vendorShowSellTooltip"]
+	local overlay = addon.db["vendorShowSellOverlay"]
+	local tooltip = addon.db["vendorShowSellTooltip"]
 
 	if not overlay and not tooltip then
 		local frames = { ContainerFrameCombinedBags }
@@ -696,7 +708,7 @@ local function AltClickHook(self, button)
 						print(REMOVE .. ":", id, name)
 					end
 				end
-                                updateSellMarks(nil, true)
+				updateSellMarks(nil, true)
 			end)
 		end
 	end

--- a/EnhanceQoLVendor/Init.lua
+++ b/EnhanceQoLVendor/Init.lua
@@ -41,6 +41,7 @@ addon.functions.InitDBValue("vendorAltClickInclude", false)
 addon.functions.InitDBValue("vendorShowSellOverlay", false)
 addon.functions.InitDBValue("vendorShowSellHighContrast", false)
 addon.functions.InitDBValue("vendorShowSellTooltip", false)
+addon.functions.InitDBValue("vendorCraftShopperEnable", false)
 
 for key, value in pairs(addon.Vendor.variables.tabNames) do
 	addon.functions.InitDBValue("vendor" .. value .. "Enable", false)

--- a/EnhanceQoLVendor/Locales/enUS.lua
+++ b/EnhanceQoLVendor/Locales/enUS.lua
@@ -19,6 +19,7 @@ L["vendorAltClickIncludeDesc"] = "Alt+Left-click an item in your inventory to ad
 L["vendorShowSellOverlay"] = "Subtle highlight on items marked for sale"
 L["vendorShowSellHighContrast"] = "High-contrast red overlay on items marked for sale"
 L["vendorShowSellTooltip"] = "Show sale marker info in tooltips"
+L["vendorCraftShopperEnable"] = "Enable Craft Shopper"
 L["bagFilterUpgradeLevel"] = "Upgrade Level"
 L["upgradeLevelVeteran"] = "Veteran"
 L["upgradeLevelChampion"] = "Champion"


### PR DESCRIPTION
## Summary
- add `vendorCraftShopperEnable` default and options checkbox
- only register Craft Shopper events when option enabled and recipes tracked
- add English localization for Craft Shopper toggle

## Testing
- `luacheck EnhanceQoLVendor/Init.lua EnhanceQoLVendor/EnhanceQoLVendor.lua EnhanceQoLVendor/CraftShopper.lua EnhanceQoLVendor/Locales/enUS.lua`


------
https://chatgpt.com/codex/tasks/task_e_689098f1d9fc8329a416ccecd74b2f94