### PR TITLE
Unregister commodity price event when canceling purchase

### DIFF
--- a/EnhanceQoLVendor/CraftShopper.lua
+++ b/EnhanceQoLVendor/CraftShopper.lua
@@ -245,6 +245,7 @@ local function ShowPurchasePopup(item, buyWidget)
 		C_AuctionHouse.CancelCommoditiesPurchase(item.itemID)
 		if popup.ticker then popup.ticker:Cancel() end
 		popup.frame:Hide()
+		f:UnregisterEvent("COMMODITY_PRICE_UPDATED")
 		AceGUI:Release(popup)
 		pendingPurchase = nil
 		buyWidget:SetDisabled(false)


### PR DESCRIPTION
## Summary
- avoid lingering commodity price updates when canceling the purchase popup

## Testing
- `luacheck EnhanceQoLVendor/CraftShopper.lua`


------
https://chatgpt.com/codex/tasks/task_e_6890e12b1de4832991c90edec3ddf68e