### PR TITLE
refactor: reuse tracked recipes before iterating

### DIFF
--- a/EnhanceQoLVendor/CraftShopper.lua
+++ b/EnhanceQoLVendor/CraftShopper.lua
@@ -95,7 +95,8 @@ local function BuildShoppingList()
 	local need = {} -- [itemID] = fehlende Menge
 
 	for _, isRecraft in ipairs(isRecraftTbl) do
-		for _, recipeID in ipairs(C_TradeSkillUI.GetRecipesTracked(isRecraft)) do
+		local recipes = C_TradeSkillUI.GetRecipesTracked(isRecraft) or {}
+		for _, recipeID in ipairs(recipes) do
 			local schem = getSchematic(recipeID, isRecraft)
 			if schem and schem.reagentSlotSchematics then
 				for _, slot in ipairs(schem.reagentSlotSchematics) do


### PR DESCRIPTION
## Summary
- cache `C_TradeSkillUI.GetRecipesTracked` into a local `recipes` table once per recraft iteration
- iterate over cached `recipes` to avoid repeated calls and handle nil

## Testing
- `stylua EnhanceQoLVendor/CraftShopper.lua`
- `luacheck EnhanceQoLVendor/CraftShopper.lua`


------
https://chatgpt.com/codex/tasks/task_e_6890e53528ec8329b63aa7b216ee9285