### PR TITLE
refactor: reuse single tooltip for query parsing

### DIFF
--- a/EnhanceQoLQuery/EnhanceQoLQuery.lua
+++ b/EnhanceQoLQuery/EnhanceQoLQuery.lua
@@ -55,8 +55,9 @@ frame.outputEditBox:SetScript("OnEnterPressed", function(self) self:ClearFocus()
 
 local addedItems = {}
 
+local tooltip = CreateFrame("GameTooltip", "EnhanceQoLQueryTooltip", UIParent, "GameTooltipTemplate")
+
 local function extractManaFromTooltip(itemLink)
-	local tooltip = CreateFrame("GameTooltip", "EnhanceQoLQueryTooltip", UIParent, "GameTooltipTemplate")
 	tooltip:SetOwner(UIParent, "ANCHOR_NONE")
 	tooltip:SetHyperlink(itemLink)
 	local mana = 0
@@ -83,7 +84,6 @@ local function extractManaFromTooltip(itemLink)
 end
 
 local function extractWellFedFromTooltip(itemLink)
-	local tooltip = CreateFrame("GameTooltip", "EnhanceQoLQueryTooltip", UIParent, "GameTooltipTemplate")
 	tooltip:SetOwner(UIParent, "ANCHOR_NONE")
 	tooltip:SetHyperlink(itemLink)
 	local buffFood = "false"


### PR DESCRIPTION
## Summary
- Instantiate a reusable `EnhanceQoLQueryTooltip` once and reference it in mana and Well Fed extraction helpers.
- Remove per-call `CreateFrame` usage in tooltip parsing to avoid redundant frames.

## Testing
- `stylua EnhanceQoLQuery/EnhanceQoLQuery.lua`
- `luacheck EnhanceQoLQuery/EnhanceQoLQuery.lua`


------
https://chatgpt.com/codex/tasks/task_e_6890fa5ccaf08329b18b86d3c4cbf09f