### PR TITLE
Avoid readding quick-buy items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Nested conditions in _Aura Tracker_ now evaluate correctly.
 - **Gem Helper** could rarely throw an error.
 - **Vendor sell overlay** sometimes remained visible after changing settings.
+- Craft Shopper no longer immediately re-lists items after quick-buying commodities.
 
 ---
 


### PR DESCRIPTION
## Summary
- prevent CraftShopper from re-listing recently quick-bought commodities
- document CraftShopper quick-buy fix

## Testing
- `stylua EnhanceQoLVendor/CraftShopper.lua`
- `luacheck EnhanceQoLVendor/CraftShopper.lua`


------
https://chatgpt.com/codex/tasks/task_e_68918f3ef3908329aac786b62b852bdf