### PR TITLE
Preserve sounds when moving casts/buffs between categories

### DIFF
--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -1838,6 +1838,21 @@ local function handleDragDrop(src, dst)
 	end
 	table.insert(addon.db["buffTrackerOrder"][dCat], insertPos, sBuff)
 
+	addon.db["buffTrackerSounds"] = addon.db["buffTrackerSounds"] or {}
+	addon.db["buffTrackerSoundsEnabled"] = addon.db["buffTrackerSoundsEnabled"] or {}
+	addon.db["buffTrackerSounds"][sCat] = addon.db["buffTrackerSounds"][sCat] or {}
+	addon.db["buffTrackerSounds"][dCat] = addon.db["buffTrackerSounds"][dCat] or {}
+	if addon.db["buffTrackerSounds"][sCat][sBuff] ~= nil then
+		addon.db["buffTrackerSounds"][dCat][sBuff] = addon.db["buffTrackerSounds"][sCat][sBuff]
+		addon.db["buffTrackerSounds"][sCat][sBuff] = nil
+	end
+	addon.db["buffTrackerSoundsEnabled"][sCat] = addon.db["buffTrackerSoundsEnabled"][sCat] or {}
+	addon.db["buffTrackerSoundsEnabled"][dCat] = addon.db["buffTrackerSoundsEnabled"][dCat] or {}
+	if addon.db["buffTrackerSoundsEnabled"][sCat][sBuff] ~= nil then
+		addon.db["buffTrackerSoundsEnabled"][dCat][sBuff] = addon.db["buffTrackerSoundsEnabled"][sCat][sBuff]
+		addon.db["buffTrackerSoundsEnabled"][sCat][sBuff] = nil
+	end
+
 	rebuildAltMapping()
 	refreshTree(selectedCategory)
 	scanBuffs()

--- a/EnhanceQoLAura/CastTracker.lua
+++ b/EnhanceQoLAura/CastTracker.lua
@@ -500,6 +500,21 @@ local function handleDragDrop(src, dst)
 	end
 	table.insert(addon.db.castTrackerOrder[dCat], insertPos, sSpell)
 
+	addon.db.castTrackerSounds = addon.db.castTrackerSounds or {}
+	addon.db.castTrackerSoundsEnabled = addon.db.castTrackerSoundsEnabled or {}
+	addon.db.castTrackerSounds[sCat] = addon.db.castTrackerSounds[sCat] or {}
+	addon.db.castTrackerSounds[dCat] = addon.db.castTrackerSounds[dCat] or {}
+	if addon.db.castTrackerSounds[sCat][sSpell] ~= nil then
+		addon.db.castTrackerSounds[dCat][sSpell] = addon.db.castTrackerSounds[sCat][sSpell]
+		addon.db.castTrackerSounds[sCat][sSpell] = nil
+	end
+	addon.db.castTrackerSoundsEnabled[sCat] = addon.db.castTrackerSoundsEnabled[sCat] or {}
+	addon.db.castTrackerSoundsEnabled[dCat] = addon.db.castTrackerSoundsEnabled[dCat] or {}
+	if addon.db.castTrackerSoundsEnabled[sCat][sSpell] ~= nil then
+		addon.db.castTrackerSoundsEnabled[dCat][sSpell] = addon.db.castTrackerSoundsEnabled[sCat][sSpell]
+		addon.db.castTrackerSoundsEnabled[sCat][sSpell] = nil
+	end
+
 	rebuildAltMapping()
 	refreshTree(selectedCategory)
 end


### PR DESCRIPTION
## Summary
- keep cast tracker sound settings when moving a spell to another category
- carry buff tracker sounds and enabled flags when reclassifying buffs

## Testing
- `stylua EnhanceQoLAura/CastTracker.lua EnhanceQoLAura/BuffTracker.lua`
- `luacheck EnhanceQoLAura/CastTracker.lua EnhanceQoLAura/BuffTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_6894de824d6083299812a3324a732020