### PR TITLE
Clean up cast tracker sound data when removing spells

### DIFF
--- a/EnhanceQoLAura/CastTracker.lua
+++ b/EnhanceQoLAura/CastTracker.lua
@@ -962,6 +962,18 @@ local function buildSpellOptions(container, catId, spellId)
 			}
 		StaticPopupDialogs["EQOL_DELETE_CAST_SPELL"].OnAccept = function()
 			cat.spells[spellId] = nil
+
+			local sounds = addon.db.castTrackerSounds
+			if sounds and sounds[catId] then
+				sounds[catId][spellId] = nil
+				if next(sounds[catId]) == nil then sounds[catId] = nil end
+			end
+			local enabled = addon.db.castTrackerSoundsEnabled
+			if enabled and enabled[catId] then
+				enabled[catId][spellId] = nil
+				if next(enabled[catId]) == nil then enabled[catId] = nil end
+			end
+
 			rebuildAltMapping()
 			refreshTree(catId)
 			container:ReleaseChildren()


### PR DESCRIPTION
## Summary
- Clean up sound configuration tables when deleting cast tracker spells, including removing empty category tables.

## Testing
- `bash scripts/build.sh` *(fails: sed: can't read s/@project-version@/4.1.1-36-gfeb894e/: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68965dd2756c8329aa3fe8b207c23f31