### PR TITLE
Clear cast category sound settings on deletion

### DIFF
--- a/EnhanceQoLAura/CastTracker.lua
+++ b/EnhanceQoLAura/CastTracker.lua
@@ -793,6 +793,8 @@ local function buildCategoryOptions(container, catId)
 			addon.db.castTrackerCategories[catId] = nil
 			addon.db.castTrackerOrder[catId] = nil
 			addon.db.castTrackerEnabled[catId] = nil
+			addon.db.castTrackerSounds[catId] = nil
+			addon.db.castTrackerSoundsEnabled[catId] = nil
 			addon.db.castTrackerLocked[catId] = nil
 			if anchors[catId] then
 				anchors[catId]:Hide()


### PR DESCRIPTION
## Summary
- remove any sound configuration when deleting a Cast Tracker category

## Testing
- `stylua EnhanceQoLAura/CastTracker.lua`
- `luacheck EnhanceQoLAura/CastTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_6896625b5efc8329a549a504d1ea0e44