### PR TITLE
feat: add quest wowhead link option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,26 @@
 ## [4.2.0] – 2025-08-07
 
 ### ✨ Added
-- **Cooldown Notify** can now track on-use **trinket** cooldowns.
-- Option to hide zone-change text.
-- 62 new **Sounds**
+
+- Added 62 new sounds.
+- Added an option to hide zone-change text.
+- Added an option to show a Wowhead quick link in quest context menus (Quest Log and Objective Tracker).
+- **Cooldown Notify** can now track on-use trinket cooldowns.
+- **Enhance Ignore:** quick ignore/unignore action in the unit context menu.
 
 ### 🔄 Changed
+
 - Performance improvements in **Aura Tracker**.
 - Performance improvements in **Cast Tracker**.
 - Performance improvements in **Mouse Trail**.
 
 ### 🐛 Fixed
-- Drag-and-drop in **Cast Tracker** / **Aura Tracker** no longer clears the assigned sounds.
+
+- Drag-and-drop in **Cast Tracker** / **Aura Tracker** no longer clears assigned sounds.
 - **P.O.S.T. Master’s Express Hearthstone** was missing from the hearthstone list.
 - **Cosmic Hearthstone** was missing from the hearthstone list.
 - Party leader icon now disappears correctly after leaving the group.
-- Deleting a **Cast Tracker** Category left some old settings
+- Deleting a **Cast Tracker** category could leave behind residual settings.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Performance improvements in **Aura Tracker**.
 - Performance improvements in **Cast Tracker**.
 - Performance improvements in **Mouse Trail**.
+- Performance improvements in **Group Filter**.
 
 ### 🐛 Fixed
 

--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -3326,6 +3326,82 @@ local function initQuest()
 	addon.functions.InitDBValue("questWowheadLink", false)
 	addon.functions.InitDBValue("ignoredQuestNPC", {})
 	addon.functions.InitDBValue("autogossipID", {})
+
+	local function EQOL_GetQuestIDFromMenu(owner, ctx)
+		if ctx and (ctx.questID or ctx.questId) then return ctx.questID or ctx.questId end
+
+		addon.db.testOwner = owner
+
+		if owner then
+			if owner.questID then return owner.questID end
+			if owner.GetQuestID then
+				local ok, id = pcall(owner.GetQuestID, owner)
+				if ok and id then return id end
+			end
+			if owner.questLogIndex and C_QuestLog and C_QuestLog.GetInfo then
+				local info = C_QuestLog.GetInfo(owner.questLogIndex)
+				if info and info.questID then return info.questID end
+			end
+		end
+		return nil
+	end
+
+	local function EQOL_ShowCopyURL(url)
+		if not StaticPopupDialogs["ENHANCEQOL_COPY_URL"] then
+			StaticPopupDialogs["ENHANCEQOL_COPY_URL"] = {
+				text = "Copy URL:",
+				button1 = OKAY,
+				hasEditBox = true,
+				timeout = 0,
+				whileDead = true,
+				hideOnEscape = true,
+				preferredIndex = 3,
+				OnShow = function(self, data)
+					local eb = self.editBox or self.GetEditBox and self:GetEditBox()
+					eb:SetAutoFocus(true)
+					eb:SetText(data or "")
+					eb:HighlightText()
+					eb:SetCursorPosition(0)
+				end,
+				OnAccept = function(self) end,
+				EditBoxOnEscapePressed = function(self) self:GetParent():Hide() end,
+			}
+		end
+		StaticPopup_Show("ENHANCEQOL_COPY_URL", nil, nil, url)
+	end
+
+	local function EQOL_AddQuestWowheadEntry(owner, root, ctx)
+		if not addon.db["questWowheadLink"] then return end
+		local qid
+		if owner.GetName and owner:GetName() == "ObjectiveTrackerFrame" then
+			local mFocus = GetMouseFoci()
+			if mFocus and mFocus[1] and mFocus[1].GetParent then
+				local pInfo = mFocus[1]:GetParent()
+				if pInfo.poiQuestID then
+					qid = pInfo.poiQuestID
+				else
+					return
+				end
+			end
+		else
+			qid = EQOL_GetQuestIDFromMenu(owner, ctx)
+		end
+		if not qid then return end
+		root:CreateDivider()
+		local btn = root:CreateButton("Copy Wowhead URL", function() EQOL_ShowCopyURL(("https://www.wowhead.com/quest=%d"):format(qid)) end)
+		btn:AddInitializer(function()
+			btn:SetTooltip(function(tt)
+				GameTooltip_SetTitle(tt, "Wowhead")
+				GameTooltip_AddNormalLine(tt, ("quest=%d"):format(qid))
+			end)
+		end)
+	end
+
+	-- Register for Blizzard's menu tags (provided by /etrace):
+	if Menu and Menu.ModifyMenu then
+		Menu.ModifyMenu("MENU_QUEST_MAP_LOG_TITLE", EQOL_AddQuestWowheadEntry)
+		Menu.ModifyMenu("MENU_QUEST_OBJECTIVE_TRACKER", EQOL_AddQuestWowheadEntry)
+	end
 end
 
 local function initMisc()
@@ -5436,87 +5512,6 @@ end
 
 local function eventHandler(self, event, ...)
 	if eventHandlers[event] then eventHandlers[event](...) end
-end
-
--- === Quest context menu integration (Wowhead link) ===
--- Adds a "Copy Wowhead URL" entry to Quest Map Log Title and Objective Tracker quest context menus.
-
--- Robustly extract questID from the menu context or owner
-local function EQOL_GetQuestIDFromMenu(owner, ctx)
-	if ctx and (ctx.questID or ctx.questId) then return ctx.questID or ctx.questId end
-
-	addon.db.testOwner = owner
-
-	if owner then
-		if owner.questID then return owner.questID end
-		if owner.GetQuestID then
-			local ok, id = pcall(owner.GetQuestID, owner)
-			if ok and id then return id end
-		end
-		if owner.questLogIndex and C_QuestLog and C_QuestLog.GetInfo then
-			local info = C_QuestLog.GetInfo(owner.questLogIndex)
-			if info and info.questID then return info.questID end
-		end
-	end
-	return nil
-end
-
--- Lightweight popup to copy a URL
-local function EQOL_ShowCopyURL(url)
-	if not StaticPopupDialogs["ENHANCEQOL_COPY_URL"] then
-		StaticPopupDialogs["ENHANCEQOL_COPY_URL"] = {
-			text = "Copy URL:",
-			button1 = OKAY,
-			hasEditBox = true,
-			timeout = 0,
-			whileDead = true,
-			hideOnEscape = true,
-			preferredIndex = 3,
-			OnShow = function(self, data)
-				local eb = self.editBox or self.GetEditBox and self:GetEditBox()
-				eb:SetAutoFocus(true)
-				eb:SetText(data or "")
-				eb:HighlightText()
-				eb:SetCursorPosition(0)
-			end,
-			OnAccept = function(self) end,
-			EditBoxOnEscapePressed = function(self) self:GetParent():Hide() end,
-		}
-	end
-	StaticPopup_Show("ENHANCEQOL_COPY_URL", nil, nil, url)
-end
-
-local function EQOL_AddQuestWowheadEntry(owner, root, ctx)
-	if not addon.db["questWowheadLink"] then return end
-	local qid
-	if owner.GetName and owner:GetName() == "ObjectiveTrackerFrame" then
-		local mFocus = GetMouseFoci()
-		if mFocus and mFocus[1] and mFocus[1].GetParent then
-			local pInfo = mFocus[1]:GetParent()
-			if pInfo.poiQuestID then
-				qid = pInfo.poiQuestID
-			else
-				return
-			end
-		end
-	else
-		qid = EQOL_GetQuestIDFromMenu(owner, ctx)
-	end
-	if not qid then return end
-	root:CreateDivider()
-	local btn = root:CreateButton("Copy Wowhead URL", function() EQOL_ShowCopyURL(("https://www.wowhead.com/quest=%d"):format(qid)) end)
-	btn:AddInitializer(function()
-		btn:SetTooltip(function(tt)
-			GameTooltip_SetTitle(tt, "Wowhead")
-			GameTooltip_AddNormalLine(tt, ("quest=%d"):format(qid))
-		end)
-	end)
-end
-
--- Register for Blizzard's menu tags (provided by /etrace):
-if Menu and Menu.ModifyMenu then
-	Menu.ModifyMenu("MENU_QUEST_MAP_LOG_TITLE", EQOL_AddQuestWowheadEntry)
-	Menu.ModifyMenu("MENU_QUEST_OBJECTIVE_TRACKER", EQOL_AddQuestWowheadEntry)
 end
 
 registerEvents(frameLoad)

--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -1,4 +1,5 @@
 -- luacheck: globals DefaultCompactUnitFrameSetup CompactUnitFrame_UpdateAuras CompactUnitFrame_UpdateName UnitTokenFromGUID C_Bank
+-- luacheck: globals Menu GameTooltip_SetTitle GameTooltip_AddNormalLine
 local addonName, addon = ...
 
 local LDB = LibStub("LibDataBroker-1.1")
@@ -2719,6 +2720,13 @@ local function addQuestFrame(container, d)
 			type = "CheckBox",
 			callback = function(self, _, value) addon.db[self.var] = value end,
 		},
+		{
+			parent = "",
+			var = "questWowheadLink",
+			text = L["questWowheadLink"],
+			type = "CheckBox",
+			callback = function(self, _, value) addon.db[self.var] = value end,
+		},
 	}
 	table.sort(groupData, function(a, b)
 		local textA = a.var
@@ -3315,6 +3323,7 @@ local function initQuest()
 	addon.functions.InitDBValue("autoChooseQuest", false)
 	addon.functions.InitDBValue("ignoreTrivialQuests", false)
 	addon.functions.InitDBValue("ignoreDailyQuests", false)
+	addon.functions.InitDBValue("questWowheadLink", false)
 	addon.functions.InitDBValue("ignoredQuestNPC", {})
 	addon.functions.InitDBValue("autogossipID", {})
 end
@@ -5427,6 +5436,71 @@ end
 
 local function eventHandler(self, event, ...)
 	if eventHandlers[event] then eventHandlers[event](...) end
+end
+
+-- === Quest context menu integration (Wowhead link) ===
+-- Adds a "Copy Wowhead URL" entry to Quest Map Log Title and Objective Tracker quest context menus.
+
+-- Robustly extract questID from the menu context or owner
+local function EQOL_GetQuestIDFromMenu(owner, ctx)
+	if ctx and (ctx.questID or ctx.questId) then return ctx.questID or ctx.questId end
+	if owner then
+		if owner.questID then return owner.questID end
+		if owner.GetQuestID then
+			local ok, id = pcall(owner.GetQuestID, owner)
+			if ok and id then return id end
+		end
+		if owner.questLogIndex and C_QuestLog and C_QuestLog.GetInfo then
+			local info = C_QuestLog.GetInfo(owner.questLogIndex)
+			if info and info.questID then return info.questID end
+		end
+	end
+	return nil
+end
+
+-- Lightweight popup to copy a URL
+local function EQOL_ShowCopyURL(url)
+	if not StaticPopupDialogs["ENHANCEQOL_COPY_URL"] then
+		StaticPopupDialogs["ENHANCEQOL_COPY_URL"] = {
+			text = "Copy URL:",
+			button1 = OKAY,
+			hasEditBox = true,
+			timeout = 0,
+			whileDead = true,
+			hideOnEscape = true,
+			preferredIndex = 3,
+			OnShow = function(self, data)
+				local eb = self.editBox or self.GetEditBox and self:GetEditBox()
+				eb:SetAutoFocus(true)
+				eb:SetText(data or "")
+				eb:HighlightText()
+				eb:SetCursorPosition(0)
+			end,
+			OnAccept = function(self) end,
+			EditBoxOnEscapePressed = function(self) self:GetParent():Hide() end,
+		}
+	end
+	StaticPopup_Show("ENHANCEQOL_COPY_URL", nil, nil, url)
+end
+
+local function EQOL_AddQuestWowheadEntry(owner, root, ctx)
+	if not addon.db["questWowheadLink"] then return end
+	local qid = EQOL_GetQuestIDFromMenu(owner, ctx)
+	if not qid then return end
+	root:CreateDivider()
+	local btn = root:CreateButton("Copy Wowhead URL", function() EQOL_ShowCopyURL(("https://www.wowhead.com/quest=%d"):format(qid)) end)
+	btn:AddInitializer(function()
+		btn:SetTooltip(function(tt)
+			GameTooltip_SetTitle(tt, "Wowhead")
+			GameTooltip_AddNormalLine(tt, ("quest=%d"):format(qid))
+		end)
+	end)
+end
+
+-- Register for Blizzard's menu tags (provided by /etrace):
+if Menu and Menu.ModifyMenu then
+	Menu.ModifyMenu("MENU_QUEST_MAP_LOG_TITLE", EQOL_AddQuestWowheadEntry)
+	Menu.ModifyMenu("MENU_QUEST_OBJECTIVE_TRACKER", EQOL_AddQuestWowheadEntry)
 end
 
 registerEvents(frameLoad)

--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -5444,6 +5444,9 @@ end
 -- Robustly extract questID from the menu context or owner
 local function EQOL_GetQuestIDFromMenu(owner, ctx)
 	if ctx and (ctx.questID or ctx.questId) then return ctx.questID or ctx.questId end
+
+	addon.db.testOwner = owner
+
 	if owner then
 		if owner.questID then return owner.questID end
 		if owner.GetQuestID then
@@ -5485,7 +5488,20 @@ end
 
 local function EQOL_AddQuestWowheadEntry(owner, root, ctx)
 	if not addon.db["questWowheadLink"] then return end
-	local qid = EQOL_GetQuestIDFromMenu(owner, ctx)
+	local qid
+	if owner.GetName and owner:GetName() == "ObjectiveTrackerFrame" then
+		local mFocus = GetMouseFoci()
+		if mFocus and mFocus[1] and mFocus[1].GetParent then
+			local pInfo = mFocus[1]:GetParent()
+			if pInfo.poiQuestID then
+				qid = pInfo.poiQuestID
+			else
+				return
+			end
+		end
+	else
+		qid = EQOL_GetQuestIDFromMenu(owner, ctx)
+	end
 	if not qid then return end
 	root:CreateDivider()
 	local btn = root:CreateButton("Copy Wowhead URL", function() EQOL_ShowCopyURL(("https://www.wowhead.com/quest=%d"):format(qid)) end)

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -114,6 +114,7 @@ L["groupfinderSkipRolecheckUseLFD"] = "Use roles from Dungeon Finder"
 L["ignoreTrivialQuests"] = "Don't automatically handle trivial %s"
 L["ignoreDailyQuests"] = "Don't automatically handle daily/weekly %s"
 L["ignoreWarbandCompleted"] = "Don't automatically handle %s %s"
+L["questWowheadLink"] = "Enable Wowhead link in quest context menus"
 
 L["autoQuickLoot"] = "Quick loot items"
 L["autoQuickLootDesc"] = "Fixes a default-UI bug that sometimes prevents you from looting. For best results, turn off WoW’s built-in Auto Loot option."

--- a/EnhanceQoL/Submodules/Ignore/Ignore.lua
+++ b/EnhanceQoL/Submodules/Ignore/Ignore.lua
@@ -1040,3 +1040,44 @@ Ignore.groupCheckFrame:SetScript("OnEvent", function()
 	Ignore.groupCheckFrame.lastPartySize = size
 	Ignore.groupCheckFrame.lastIgnored = count
 end)
+
+local function EQOL_AddUnitIgnoreEntry(owner, root, ctx)
+	if not Ignore.enabled then return end
+	local name = ctx and ctx.name
+	local realm = ctx and ctx.server
+	if name and not name:find("-") then
+		realm = realm or (GetRealmName()):gsub("%s", "")
+		name = name .. "-" .. realm
+	end
+	if not name then
+		local unit = (ctx and ctx.unit) or (owner and owner.unit) or (owner and owner.GetUnit and owner:GetUnit())
+		if unit and UnitName then
+			local n, r = UnitName(unit)
+			if n then
+				r = r and r ~= "" and r or (GetRealmName()):gsub("%s", "")
+				name = n .. "-" .. r
+			end
+		end
+	end
+	if not name then return end
+
+	local isIgnored = Ignore:CheckIgnore(name) ~= nil
+
+	local label = isIgnored and _G.UNIGNORE_QUEST or _G.IGNORE_PLAYER
+
+	root:CreateDivider()
+	root:CreateButton(label, function()
+		if isIgnored then
+			C_FriendList.DelIgnore(name)
+		else
+			C_FriendList.AddIgnore(name)
+		end
+	end)
+end
+
+if Menu and Menu.ModifyMenu then
+	Menu.ModifyMenu("MENU_UNIT_PLAYER", EQOL_AddUnitIgnoreEntry)
+	Menu.ModifyMenu("MENU_UNIT_ENEMY_PLAYER", EQOL_AddUnitIgnoreEntry)
+	Menu.ModifyMenu("MENU_UNIT_RAID_PLAYER", EQOL_AddUnitIgnoreEntry)
+	Menu.ModifyMenu("MENU_UNIT_PARTY", EQOL_AddUnitIgnoreEntry)
+end

--- a/EnhanceQoLMythicPlus/DungeonFilter.lua
+++ b/EnhanceQoLMythicPlus/DungeonFilter.lua
@@ -122,37 +122,26 @@ drop:HookScript("OnHide", function()
 	wipe(SearchInfoCache)
 end)
 
-hooksecurefunc(drop, "SetupMenu", function(self, blizzGen)
+local function EQOL_AddLFGEntries(owner, root, ctx)
 	if not addon.db["mythicPlusEnableDungeonFilter"] then return end
 	local panel = LFGListFrame.SearchPanel
 	if panel.categoryID ~= 2 then return end
-	if originalSetupGen and blizzGen ~= originalSetupGen then return end
-	originalSetupGen = originalSetupGen or blizzGen
+	root:CreateTitle("")
 
-	local function EQOL_Generator(menu, root)
-		blizzGen(menu, root)
-
-		root:CreateTitle("")
-
-		root:CreateTitle(addonName)
-		root:CreateCheckbox(L["Partyfit"], function() return pDb["partyFit"] end, function() pDb["partyFit"] = not pDb["partyFit"] end)
-		if not playerIsLust then
-			root:CreateCheckbox(L["BloodlustAvailable"], function() return pDb["bloodlustAvailable"] end, function() pDb["bloodlustAvailable"] = not pDb["bloodlustAvailable"] end)
-		end
-		if not playerIsBR then
-			root:CreateCheckbox(L["BattleResAvailable"], function() return pDb["battleResAvailable"] end, function() pDb["battleResAvailable"] = not pDb["battleResAvailable"] end)
-		end
-		if addon.variables.unitRole == "DAMAGER" then
-			root:CreateCheckbox(
-				(L["NoSameSpec"]):format(addon.variables.unitSpecName .. " " .. select(1, UnitClass("player"))),
-				function() return pDb["NoSameSpec"] end,
-				function() pDb["NoSameSpec"] = not pDb["NoSameSpec"] end
-			)
-		end
+	root:CreateTitle(addonName)
+	root:CreateCheckbox(L["Partyfit"], function() return pDb["partyFit"] end, function() pDb["partyFit"] = not pDb["partyFit"] end)
+	if not playerIsLust then root:CreateCheckbox(L["BloodlustAvailable"], function() return pDb["bloodlustAvailable"] end, function() pDb["bloodlustAvailable"] = not pDb["bloodlustAvailable"] end) end
+	if not playerIsBR then root:CreateCheckbox(L["BattleResAvailable"], function() return pDb["battleResAvailable"] end, function() pDb["battleResAvailable"] = not pDb["battleResAvailable"] end) end
+	if addon.variables.unitRole == "DAMAGER" then
+		root:CreateCheckbox(
+			(L["NoSameSpec"]):format(addon.variables.unitSpecName .. " " .. select(1, UnitClass("player"))),
+			function() return pDb["NoSameSpec"] end,
+			function() pDb["NoSameSpec"] = not pDb["NoSameSpec"] end
+		)
 	end
-	self:SetupMenu(EQOL_Generator)
-	self.isSet = true
-end)
+end
+
+if Menu and Menu.ModifyMenu then Menu.ModifyMenu("MENU_LFG_FRAME_SEARCH_FILTER", EQOL_AddLFGEntries) end
 
 local function MyCustomFilter(info)
 	if appliedLookup[info.searchResultID] then return true end

--- a/EnhanceQoLMythicPlus/DungeonFilter.lua
+++ b/EnhanceQoLMythicPlus/DungeonFilter.lua
@@ -35,8 +35,8 @@ local BR_CLASSES = { DRUID = true, WARLOCK = true, DEATHKNIGHT = true, PALADIN =
 
 local SearchInfoCache = {}
 
-local scanGen = 0           -- generation counter for pruning the cache
-local toRemove = {}         -- reusable array to avoid reallocations
+local scanGen = 0 -- generation counter for pruning the cache
+local toRemove = {} -- reusable array to avoid reallocations
 
 local function CacheResultInfo(resultID)
 	local info = C_LFGList.GetSearchResultInfo(resultID)
@@ -84,26 +84,22 @@ local function EnsureExtraInfo(resultID, needRoles, needLust, needBR, needSameSp
 			end
 			if (needLust or needBR) and m.classFilename then
 				if needLust and LUST_CLASSES[m.classFilename] then lust = true end
-				if needBR   and BR_CLASSES[m.classFilename]   then br   = true end
+				if needBR and BR_CLASSES[m.classFilename] then br = true end
 			end
-			if needSameSpec and m.classFilename == addon.variables.unitClass and m.specName == addon.variables.unitSpecName then
-				sameSpec = true
-			end
+			if needSameSpec and m.classFilename == addon.variables.unitClass and m.specName == addon.variables.unitSpecName then sameSpec = true end
 			-- Early exit: wenn alle angeforderten Infos schon feststehen
 			local rolesDone = (not needRoles) or ((tank + healer + dps) >= info.numMembers)
-			if rolesDone and (not needLust or lust) and (not needBR or br) and (not needSameSpec or sameSpec) then
-				break
-			end
+			if rolesDone and (not needLust or lust) and (not needBR or br) and (not needSameSpec or sameSpec) then break end
 		end
 	end
 
 	if needRoles then
-		info.groupTankCount   = tank
+		info.groupTankCount = tank
 		info.groupHealerCount = healer
-		info.groupDPSCount    = dps
+		info.groupDPSCount = dps
 	end
-	if needLust     then info.hasLust    = lust end
-	if needBR       then info.hasBR      = br   end
+	if needLust then info.hasLust = lust end
+	if needBR then info.hasBR = br end
 	if needSameSpec then info.hasSameSpec = sameSpec end
 	-- Einmal berechnet reicht pro Generation
 	info.extraCalculated = true
@@ -176,20 +172,18 @@ local function MyCustomFilter(info)
 
 	-- Welche Details brauchen wir wirklich?
 	local NEED_SAMESPEC = (addon.variables.unitRole == "DAMAGER") and pDb["NoSameSpec"] or false
-	local NEED_LUST     = pDb["bloodlustAvailable"] and not partyHasLust
-	local NEED_BR       = pDb["battleResAvailable"] and not partyHasBR
-	local NEED_ROLES    = pDb["partyFit"]
+	local NEED_LUST = pDb["bloodlustAvailable"] and not partyHasLust
+	local NEED_BR = pDb["battleResAvailable"] and not partyHasBR
+	local NEED_ROLES = pDb["partyFit"]
 
-	if NEED_SAMESPEC or NEED_LUST or NEED_BR or NEED_ROLES then
-		info = EnsureExtraInfo(info.searchResultID, NEED_ROLES, NEED_LUST, NEED_BR, NEED_SAMESPEC) or info
-	end
+	if NEED_SAMESPEC or NEED_LUST or NEED_BR or NEED_ROLES then info = EnsureExtraInfo(info.searchResultID, NEED_ROLES, NEED_LUST, NEED_BR, NEED_SAMESPEC) or info end
 
-	local groupTankCount   = info.groupTankCount   or 0
+	local groupTankCount = info.groupTankCount or 0
 	local groupHealerCount = info.groupHealerCount or 0
-	local groupDPSCount    = info.groupDPSCount    or 0
-	local hasLust          = info.hasLust          or false
-	local hasBR            = info.hasBR            or false
-	local hasSameSpec      = info.hasSameSpec      or false
+	local groupDPSCount = info.groupDPSCount or 0
+	local hasLust = info.hasLust or false
+	local hasBR = info.hasBR or false
+	local hasSameSpec = info.hasSameSpec or false
 
 	if NEED_SAMESPEC and hasSameSpec then return false end
 
@@ -256,8 +250,14 @@ local function ApplyEQOLFilters(isInitial)
 	wipe(toRemove)
 
 	-- Basic guards
-	if not drop or not drop:IsVisible() then _eqolFiltering = false; return end
-	if not addon.db["mythicPlusEnableDungeonFilter"] then _eqolFiltering = false; return end
+	if not drop or not drop:IsVisible() then
+		_eqolFiltering = false
+		return
+	end
+	if not addon.db["mythicPlusEnableDungeonFilter"] then
+		_eqolFiltering = false
+		return
+	end
 
 	local panel = LFGListFrame and LFGListFrame.SearchPanel
 	if not panel or panel.categoryID ~= 2 then
@@ -266,14 +266,17 @@ local function ApplyEQOLFilters(isInitial)
 		return
 	end
 	local dp = panel.ScrollBox and panel.ScrollBox:GetDataProvider()
-	if not dp then _eqolFiltering = false; return end
+	if not dp then
+		_eqolFiltering = false
+		return
+	end
 
 	-- Fast exit if nothing to filter (mirrors the old conditions)
 	local needFilter = false
-	if (pDb["bloodlustAvailable"] and not playerIsLust) then needFilter = true end
-	if (pDb["battleResAvailable"] and not playerIsBR) then needFilter = true end
+	if pDb["bloodlustAvailable"] and not playerIsLust then needFilter = true end
+	if pDb["battleResAvailable"] and not playerIsBR then needFilter = true end
 	if pDb["partyFit"] then needFilter = true end
-	if (pDb["NoSameSpec"] and addon.variables.unitRole == "DAMAGER") then needFilter = true end
+	if pDb["NoSameSpec"] and addon.variables.unitRole == "DAMAGER" then needFilter = true end
 	if not needFilter then
 		titleScore1:Hide()
 		_eqolFiltering = false
@@ -301,9 +304,7 @@ local function ApplyEQOLFilters(isInitial)
 				SearchInfoCache[resultID].extraCalculated = nil -- Details können sich geändert haben
 			end
 			local info = SearchInfoCache[resultID]
-			if info and not MyCustomFilter(info) then
-				toRemove[#toRemove+1] = { elem = element, id = resultID }
-			end
+			if info and not MyCustomFilter(info) then toRemove[#toRemove + 1] = { elem = element, id = resultID } end
 		end
 	end
 
@@ -337,9 +338,7 @@ local function ApplyEQOLFilters(isInitial)
 
 	-- Prune alte Cache-Einträge, die in diesem Pass nicht gesehen wurden
 	for id, c in pairs(SearchInfoCache) do
-		if c._gen ~= scanGen then
-			SearchInfoCache[id] = nil
-		end
+		if c._gen ~= scanGen then SearchInfoCache[id] = nil end
 	end
 
 	_eqolFiltering = false


### PR DESCRIPTION
## Summary
- allow copying a quest's Wowhead URL from quest map and objective tracker context menus when enabled
- add Quest option and locale for enabling the Wowhead link

## Testing
- `stylua --indent-type Tabs EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`
- `luacheck EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`


------
https://chatgpt.com/codex/tasks/task_e_689667db49e883299240d58340eea5a3