### PR TITLE
CombatMeter ticker with configurable update rate

### DIFF
--- a/EnhanceQoLCombatMeter/Init.lua
+++ b/EnhanceQoLCombatMeter/Init.lua
@@ -13,6 +13,7 @@ addon.LCombatMeter = {}
 addon.functions.InitDBValue("combatMeterEnabled", false)
 addon.functions.InitDBValue("combatMeterHistory", {})
 addon.functions.InitDBValue("combatMeterAlwaysShow", false)
+addon.functions.InitDBValue("combatMeterUpdateRate", 0.2)
 addon.functions.InitDBValue("combatMeterFramePoint", "CENTER")
 addon.functions.InitDBValue("combatMeterFrameX", 0)
 addon.functions.InitDBValue("combatMeterFrameY", 0)


### PR DESCRIPTION
## Summary
- add `combatMeterUpdateRate` database value
- use `C_Timer.NewTicker` to refresh Combat Meter bars using DPS/HPS
- cancel ticker when combat ends

## Testing
- `stylua EnhanceQoLCombatMeter/Init.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/Init.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_6899e07b728883298f0f4f8f4563b55b