### PR TITLE
Add Combat Meter options

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -4829,6 +4829,8 @@ local function CreateUI()
 			addon.SharedMedia.functions.treeCallback(container, group)
 		elseif string.match(group, "^mouse") then
 			addon.Mouse.functions.treeCallback(container, group)
+		elseif string.match(group, "^combatmeter") then
+			addon.CombatMeter.functions.treeCallback(container, group)
 		elseif string.match(group, "^move") then
 			addon.LayoutTools.functions.treeCallback(container, group)
 		end
@@ -5299,6 +5301,7 @@ local eventHandlers = {
 			loadSubAddon("EnhanceQoLSound")
 			loadSubAddon("EnhanceQoLMouse")
 			loadSubAddon("EnhanceQoLMythicPlus")
+			loadSubAddon("EnhanceQoLCombatMeter")
 			loadSubAddon("EnhanceQoLDrinkMacro")
 			loadSubAddon("EnhanceQoLTooltip")
 			loadSubAddon("EnhanceQoLVendor")

--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -81,11 +81,39 @@ local function handleEvent(self, event, ...)
 end
 
 frame:SetScript("OnEvent", handleEvent)
-frame:RegisterEvent("PLAYER_REGEN_DISABLED")
-frame:RegisterEvent("PLAYER_REGEN_ENABLED")
-frame:RegisterEvent("ENCOUNTER_START")
-frame:RegisterEvent("ENCOUNTER_END")
-frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+
+function addon.CombatMeter.functions.toggle(enabled)
+	if enabled then
+		frame:RegisterEvent("PLAYER_REGEN_DISABLED")
+		frame:RegisterEvent("PLAYER_REGEN_ENABLED")
+		frame:RegisterEvent("ENCOUNTER_START")
+		frame:RegisterEvent("ENCOUNTER_END")
+		frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+		if addon.CombatMeter.uiFrame then
+			addon.CombatMeter.uiFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
+			addon.CombatMeter.uiFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+			addon.CombatMeter.uiFrame:RegisterEvent("ENCOUNTER_START")
+			addon.CombatMeter.uiFrame:RegisterEvent("ENCOUNTER_END")
+		end
+	else
+		frame:UnregisterAllEvents()
+		addon.CombatMeter.inCombat = false
+		addon.CombatMeter.fightDuration = 0
+		addon.CombatMeter.overallDuration = 0
+		releasePlayers(addon.CombatMeter.players)
+		releasePlayers(addon.CombatMeter.overallPlayers)
+		if addon.CombatMeter.uiFrame then
+			addon.CombatMeter.uiFrame:UnregisterAllEvents()
+			addon.CombatMeter.uiFrame:Hide()
+		end
+		if addon.CombatMeter.ticker then
+			addon.CombatMeter.ticker:Cancel()
+			addon.CombatMeter.ticker = nil
+		end
+	end
+end
+
+addon.CombatMeter.functions.toggle(addon.db["combatMeterEnabled"])
 
 SLASH_EQOLCM1 = "/eqolcm"
 SlashCmdList["EQOLCM"] = function(msg)

--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -146,20 +146,30 @@ local function UpdateBars()
 	frame:SetHeight(16 + #list * barHeight)
 end
 
-frame:RegisterEvent("PLAYER_REGEN_DISABLED")
-frame:RegisterEvent("PLAYER_REGEN_ENABLED")
-frame:RegisterEvent("ENCOUNTER_START")
-frame:RegisterEvent("ENCOUNTER_END")
+addon.CombatMeter.functions.UpdateBars = UpdateBars
+
 frame:SetScript("OnEvent", function(self, event)
 	if event == "PLAYER_REGEN_DISABLED" or event == "ENCOUNTER_START" then
 		if ticker then ticker:Cancel() end
 		ticker = C_Timer.NewTicker(config["combatMeterUpdateRate"], UpdateBars)
+		addon.CombatMeter.ticker = ticker
 		C_Timer.After(0, UpdateBars)
 	else
 		if ticker then
 			ticker:Cancel()
 			ticker = nil
+			addon.CombatMeter.ticker = nil
 		end
 		C_Timer.After(0, UpdateBars)
 	end
 end)
+
+function addon.CombatMeter.functions.setUpdateRate(rate)
+	if ticker then
+		ticker:Cancel()
+		ticker = C_Timer.NewTicker(rate, UpdateBars)
+		addon.CombatMeter.ticker = ticker
+	end
+end
+
+addon.CombatMeter.functions.toggle(addon.db["combatMeterEnabled"])

--- a/EnhanceQoLCombatMeter/Init.lua
+++ b/EnhanceQoLCombatMeter/Init.lua
@@ -1,5 +1,6 @@
 local parentAddonName = "EnhanceQoL"
 local addonName, addon = ...
+-- luacheck: globals GENERAL SlashCmdList
 if _G[parentAddonName] then
 	addon = _G[parentAddonName]
 else
@@ -9,6 +10,50 @@ end
 addon.CombatMeter = {}
 addon.CombatMeter.functions = {}
 addon.LCombatMeter = {}
+
+local AceGUI = addon.AceGUI
+local L = LibStub("AceLocale-3.0"):GetLocale("EnhanceQoL_CombatMeter")
+
+addon.variables.statusTable.groups["combatmeter"] = true
+addon.functions.addToTree(nil, {
+	value = "combatmeter",
+	text = L["Combat Meter"],
+	children = {
+		{ value = "general", text = GENERAL },
+	},
+})
+
+local function addGeneralFrame(container)
+	local wrapper = addon.functions.createContainer("SimpleGroup", "Flow")
+	container:AddChild(wrapper)
+
+	local groupCore = addon.functions.createContainer("InlineGroup", "List")
+	wrapper:AddChild(groupCore)
+
+	local cbEnabled = addon.functions.createCheckboxAce(L["Enabled"], addon.db["combatMeterEnabled"], function(self, _, value)
+		addon.db["combatMeterEnabled"] = value
+		addon.CombatMeter.functions.toggle(value)
+	end)
+	groupCore:AddChild(cbEnabled)
+
+	local sliderRate = addon.functions.createSliderAce(L["Update Rate"] .. ": " .. addon.db["combatMeterUpdateRate"], addon.db["combatMeterUpdateRate"], 0.05, 1, 0.05, function(self, _, val)
+		addon.db["combatMeterUpdateRate"] = val
+		addon.CombatMeter.functions.setUpdateRate(val)
+		self:SetLabel(L["Update Rate"] .. ": " .. string.format("%.2f", val))
+	end)
+	groupCore:AddChild(sliderRate)
+
+	local btnReset = addon.functions.createButtonAce(L["Reset"], nil, function()
+		if SlashCmdList and SlashCmdList["EQOLCM"] then SlashCmdList["EQOLCM"]("reset") end
+		if addon.CombatMeter.functions.UpdateBars then addon.CombatMeter.functions.UpdateBars() end
+	end)
+	groupCore:AddChild(btnReset)
+end
+
+function addon.CombatMeter.functions.treeCallback(container, group)
+	container:ReleaseChildren()
+	if group == "combatmeter\001general" then addGeneralFrame(container) end
+end
 
 addon.functions.InitDBValue("combatMeterEnabled", false)
 addon.functions.InitDBValue("combatMeterHistory", {})

--- a/EnhanceQoLCombatMeter/Locales/deDE.lua
+++ b/EnhanceQoLCombatMeter/Locales/deDE.lua
@@ -2,3 +2,6 @@ local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_CombatMeter", "deDE")
 if not L then return end
 
 L["Combat Meter"] = "Kampf-Meter"
+L["Enabled"] = "Aktiviert"
+L["Update Rate"] = "Aktualisierungsrate"
+L["Reset"] = "Zurücksetzen"

--- a/EnhanceQoLCombatMeter/Locales/enUS.lua
+++ b/EnhanceQoLCombatMeter/Locales/enUS.lua
@@ -1,3 +1,6 @@
 local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_CombatMeter", "enUS", true)
 
 L["Combat Meter"] = "Combat Meter"
+L["Enabled"] = "Enabled"
+L["Update Rate"] = "Update Rate"
+L["Reset"] = "Reset"


### PR DESCRIPTION
## Summary
- add Combat Meter as a loadable module and hook it into the options tree
- provide enable toggle, update rate slider and reset button for Combat Meter
- allow live toggling and update-rate changes through exported functions

## Testing
- `luacheck EnhanceQoL/EnhanceQoL.lua EnhanceQoLCombatMeter/Init.lua EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_6899e1f885508329980c3967b1eba57c