### PR TITLE
feat(combatmeter): add always show option

### DIFF
--- a/EnhanceQoLCombatMeter/Init.lua
+++ b/EnhanceQoLCombatMeter/Init.lua
@@ -30,18 +30,24 @@ local function addGeneralFrame(container)
 	local groupCore = addon.functions.createContainer("InlineGroup", "List")
 	wrapper:AddChild(groupCore)
 
-	local cbEnabled = addon.functions.createCheckboxAce(L["Enabled"], addon.db["combatMeterEnabled"], function(self, _, value)
-		addon.db["combatMeterEnabled"] = value
-		addon.CombatMeter.functions.toggle(value)
-	end)
-	groupCore:AddChild(cbEnabled)
+        local cbEnabled = addon.functions.createCheckboxAce(L["Enabled"], addon.db["combatMeterEnabled"], function(self, _, value)
+                addon.db["combatMeterEnabled"] = value
+                addon.CombatMeter.functions.toggle(value)
+        end)
+        groupCore:AddChild(cbEnabled)
 
-	local sliderRate = addon.functions.createSliderAce(L["Update Rate"] .. ": " .. addon.db["combatMeterUpdateRate"], addon.db["combatMeterUpdateRate"], 0.05, 1, 0.05, function(self, _, val)
-		addon.db["combatMeterUpdateRate"] = val
-		addon.CombatMeter.functions.setUpdateRate(val)
-		self:SetLabel(L["Update Rate"] .. ": " .. string.format("%.2f", val))
-	end)
-	groupCore:AddChild(sliderRate)
+        local cbAlwaysShow = addon.functions.createCheckboxAce(L["Always Show"], addon.db["combatMeterAlwaysShow"], function(self, _, value)
+                addon.db["combatMeterAlwaysShow"] = value
+                if addon.CombatMeter.functions.UpdateBars then addon.CombatMeter.functions.UpdateBars() end
+        end)
+        groupCore:AddChild(cbAlwaysShow)
+
+        local sliderRate = addon.functions.createSliderAce(L["Update Rate"] .. ": " .. addon.db["combatMeterUpdateRate"], addon.db["combatMeterUpdateRate"], 0.05, 1, 0.05, function(self, _, val)
+                addon.db["combatMeterUpdateRate"] = val
+                addon.CombatMeter.functions.setUpdateRate(val)
+                self:SetLabel(L["Update Rate"] .. ": " .. string.format("%.2f", val))
+        end)
+        groupCore:AddChild(sliderRate)
 
 	local btnReset = addon.functions.createButtonAce(L["Reset"], nil, function()
 		if SlashCmdList and SlashCmdList["EQOLCM"] then SlashCmdList["EQOLCM"]("reset") end

--- a/EnhanceQoLCombatMeter/Locales/deDE.lua
+++ b/EnhanceQoLCombatMeter/Locales/deDE.lua
@@ -3,5 +3,6 @@ if not L then return end
 
 L["Combat Meter"] = "Kampf-Meter"
 L["Enabled"] = "Aktiviert"
+L["Always Show"] = "Immer anzeigen"
 L["Update Rate"] = "Aktualisierungsrate"
 L["Reset"] = "Zurücksetzen"

--- a/EnhanceQoLCombatMeter/Locales/enUS.lua
+++ b/EnhanceQoLCombatMeter/Locales/enUS.lua
@@ -2,5 +2,6 @@ local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_CombatMeter", "enUS", t
 
 L["Combat Meter"] = "Combat Meter"
 L["Enabled"] = "Enabled"
+L["Always Show"] = "Always Show"
 L["Update Rate"] = "Update Rate"
 L["Reset"] = "Reset"


### PR DESCRIPTION
## Summary
- add Combat Meter config toggle to always show bars
- update translations for new option

## Testing
- `luac -p EnhanceQoLCombatMeter/Init.lua EnhanceQoLCombatMeter/Locales/enUS.lua EnhanceQoLCombatMeter/Locales/deDE.lua`


------
https://chatgpt.com/codex/tasks/task_e_6899e9269ff08329906d28ef2354d370