### PR TITLE
fix: show total damage in overall meter

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -117,7 +117,12 @@ local function createGroupFrame(groupConfig)
 			local stats = addon.CombatMeter.functions.getOverallStats()
 			for guid, p in pairs(stats) do
 				if groupUnits[guid] then
-					local value = self.metric == "damageOverall" and p.dps or p.hps
+					local value
+					if self.metric == "damageOverall" then
+						value = p.damage
+					else
+						value = p.hps
+					end
 					table.insert(list, { guid = guid, name = p.name, value = value })
 					if value > maxValue then maxValue = value end
 				end


### PR DESCRIPTION
## Summary
- show total damage for the overall damage meter

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeterUI.lua EnhanceQoLCombatMeter/CombatMeter.lua`


------
https://chatgpt.com/codex/tasks/task_e_6899fd84aa2483298dbc9d41b0057d8a