### PR TITLE
Handle specialization icon retrieval asynchronously

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -142,6 +142,8 @@ function addon.CombatMeter.functions.toggle(enabled)
 			addon.CombatMeter.uiFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 			addon.CombatMeter.uiFrame:RegisterEvent("ENCOUNTER_START")
 			addon.CombatMeter.uiFrame:RegisterEvent("ENCOUNTER_END")
+			addon.CombatMeter.uiFrame:RegisterEvent("INSPECT_READY")
+			addon.CombatMeter.uiFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 		end
 	else
 		frame:UnregisterAllEvents()


### PR DESCRIPTION
## Summary
- Resolve GetInspectSpecialization returning 0 by requesting inspect data and waiting for INSPECT_READY
- Refresh specialization icons when group members change specs and handle player's icon locally

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeterUI.lua EnhanceQoLCombatMeter/CombatMeter.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeterUI.lua EnhanceQoLCombatMeter/CombatMeter.lua`


------
https://chatgpt.com/codex/tasks/task_e_689a13c0a79c8329ad9be5cf5db63999