### PR TITLE
feat: allow always showing self in combat meter groups

### DIFF
--- a/EnhanceQoLCombatMeter/Init.lua
+++ b/EnhanceQoLCombatMeter/Init.lua
@@ -111,6 +111,12 @@ local function addGeneralFrame(container)
 			addon.CombatMeter.functions.rebuildGroups()
 		end)
 		groupGroup:AddChild(smb)
+
+		local cbSelf = addon.functions.createCheckboxAce(L["Always Show Self"], cfg.alwaysShowSelf or false, function(self, _, value)
+			cfg.alwaysShowSelf = value
+			addon.CombatMeter.functions.rebuildGroups()
+		end)
+		groupGroup:AddChild(cbSelf)
 	end
 
 	local addDrop = addon.functions.createDropdownAce(L["Add Group"], metricNames, metricOrder, function(self, _, val)
@@ -122,6 +128,7 @@ local function addGeneralFrame(container)
 			barWidth = 210,
 			barHeight = 25,
 			maxBars = 8,
+			alwaysShowSelf = false,
 		})
 		addon.CombatMeter.functions.rebuildGroups()
 		container:ReleaseChildren()
@@ -149,5 +156,6 @@ addon.functions.InitDBValue("combatMeterGroups", {
 		barWidth = 210,
 		barHeight = 25,
 		maxBars = 8,
+		alwaysShowSelf = false,
 	},
 })

--- a/EnhanceQoLCombatMeter/Locales/deDE.lua
+++ b/EnhanceQoLCombatMeter/Locales/deDE.lua
@@ -4,6 +4,7 @@ if not L then return end
 L["Combat Meter"] = "Kampf-Meter"
 L["Enabled"] = "Aktiviert"
 L["Always Show"] = "Immer anzeigen"
+L["Always Show Self"] = "Sich selbst immer anzeigen"
 L["Update Rate"] = "Aktualisierungsrate"
 L["Font Size"] = "Schriftgröße"
 L["Reset"] = "Zurücksetzen"

--- a/EnhanceQoLCombatMeter/Locales/enUS.lua
+++ b/EnhanceQoLCombatMeter/Locales/enUS.lua
@@ -3,6 +3,7 @@ local L = LibStub("AceLocale-3.0"):NewLocale("EnhanceQoL_CombatMeter", "enUS", t
 L["Combat Meter"] = "Combat Meter"
 L["Enabled"] = "Enabled"
 L["Always Show"] = "Always Show"
+L["Always Show Self"] = "Always Show Self"
 L["Update Rate"] = "Update Rate"
 L["Font Size"] = "Font Size"
 L["Reset"] = "Reset"


### PR DESCRIPTION
## Summary
- add per-group checkbox to always show the player and persist its value
- show player's stats even when not ranked and make room within max bars
- localize "Always Show Self" text

## Testing
- `stylua EnhanceQoLCombatMeter/Init.lua EnhanceQoLCombatMeter/CombatMeterUI.lua EnhanceQoLCombatMeter/Locales/enUS.lua EnhanceQoLCombatMeter/Locales/deDE.lua`
- `luacheck EnhanceQoLCombatMeter/Init.lua EnhanceQoLCombatMeter/CombatMeterUI.lua EnhanceQoLCombatMeter/Locales/enUS.lua EnhanceQoLCombatMeter/Locales/deDE.lua`

------
https://chatgpt.com/codex/tasks/task_e_689a1fae1edc832986304d2781d04c5c