### PR TITLE
Ensure CombatMeter cleans up properly when disabled

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -173,6 +173,7 @@ function addon.CombatMeter.functions.toggle(enabled)
 			addon.CombatMeter.uiFrame:UnregisterAllEvents()
 			addon.CombatMeter.uiFrame:Hide()
 		end
+		if addon.CombatMeter.functions and addon.CombatMeter.functions.hideAllFrames then addon.CombatMeter.functions.hideAllFrames() end
 		if addon.CombatMeter.ticker then
 			addon.CombatMeter.ticker:Cancel()
 			addon.CombatMeter.ticker = nil

--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -478,5 +478,14 @@ local function rebuildGroups()
 end
 addon.CombatMeter.functions.rebuildGroups = rebuildGroups
 
+local function hideAllFrames()
+	for _, frame in ipairs(groupFrames) do
+		frame:Hide()
+	end
+	wipe(specIcons)
+	wipe(pendingInspect)
+end
+addon.CombatMeter.functions.hideAllFrames = hideAllFrames
+
 rebuildGroups()
 addon.CombatMeter.functions.toggle(addon.db["combatMeterEnabled"])


### PR DESCRIPTION
## Summary
- hide all CombatMeter frames and clear cached data when disabling the module
- invoke new cleanup from toggle to remove windows and unregister events

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua` (2 warnings, 0 errors)


------
https://chatgpt.com/codex/tasks/task_e_689a2792304c8329ad93c3cb77615755