### PR TITLE
fix: refresh combat meter on group changes

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -159,6 +159,7 @@ function addon.CombatMeter.functions.toggle(enabled)
 			addon.CombatMeter.uiFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 			addon.CombatMeter.uiFrame:RegisterEvent("ENCOUNTER_START")
 			addon.CombatMeter.uiFrame:RegisterEvent("ENCOUNTER_END")
+			addon.CombatMeter.uiFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
 			addon.CombatMeter.uiFrame:RegisterEvent("INSPECT_READY")
 			addon.CombatMeter.uiFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 		end

--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -444,6 +444,15 @@ controller:SetScript("OnEvent", function(self, event, ...)
 				NotifyInspect(unit)
 			end
 		end
+	elseif event == "GROUP_ROSTER_UPDATE" then
+		local groupUnits = buildGroupUnits()
+		for guid in pairs(specIcons) do
+			if not groupUnits[guid] then
+				specIcons[guid] = nil
+				pendingInspect[guid] = nil
+			end
+		end
+		C_Timer.After(0, UpdateAllFrames)
 	else
 		if ticker then
 			ticker:Cancel()


### PR DESCRIPTION
## Summary
- Refresh CombatMeter UI when group roster changes
- Clear stored spec icons for players no longer in the group

## Testing
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_689a28e472e88329b261229d9f987659