### PR TITLE
Optimize combat log event parsing for absorption data

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -87,7 +87,11 @@ local function handleEvent(self, event, ...)
 		table.insert(addon.db["combatMeterHistory"], 1, fight)
 	elseif event == "COMBAT_LOG_EVENT_UNFILTERED" then
 		if not addon.CombatMeter.inCombat then return end
-		local _, subevent, _, sourceGUID, sourceName, sourceFlags, _, _, _, _, _, a12, a13, a14, a15, a16, a17, a18, a19, a20 = CombatLogGetCurrentEventInfo()
+		local a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25 = CombatLogGetCurrentEventInfo()
+		local subevent = a2
+		local sourceGUID = a4
+		local sourceName = a5
+		local sourceFlags = a6
 		if not dmgIdx[subevent] and not healIdx[subevent] and not subevent == "SPELL_ABSORBED" then return end
 		if not sourceGUID or bit_band(sourceFlags or 0, groupMask) == 0 then return end
 
@@ -118,12 +122,12 @@ local function handleEvent(self, event, ...)
 			-- SPELL_ABSORBED has variable arg layouts; the last 8 fields are stable:
 			-- absorberGUID, absorberName, absorberFlags, absorberRaidFlags,
 			-- absorbingSpellID, absorbingSpellName, absorbingSpellSchool, absorbedAmount
-			local data = { CombatLogGetCurrentEventInfo() }
-			local n = #data
-			local absorberGUID = data[n - 7]
-			local absorberName = data[n - 6]
-			local absorberFlags = data[n - 5]
-			local absorbedAmount = data[n] or 0
+			local a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25 = CombatLogGetCurrentEventInfo()
+			local n = select("#", a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)
+			local absorberGUID = select(n - 7, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)
+			local absorberName = select(n - 6, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)
+			local absorberFlags = select(n - 5, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)
+			local absorbedAmount = select(n, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25) or 0
 			if absorbedAmount > 0 and absorberGUID and bit_band(absorberFlags or 0, groupMask) ~= 0 then
 				local p = acquirePlayer(addon.CombatMeter.players, absorberGUID, absorberName)
 				local o = acquirePlayer(addon.CombatMeter.overallPlayers, absorberGUID, absorberName)


### PR DESCRIPTION
## Summary
- Replace table-based CombatLogGetCurrentEventInfo() usage with explicit varargs
- Use select() to derive argument count and extract absorber details

## Testing
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua`
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua`

------
https://chatgpt.com/codex/tasks/task_e_689a30bfb1ec8329994c530de9f265d9