### PR TITLE
Limit stored combat history to 30 fights

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -102,7 +102,9 @@ local function handleEvent(self, event, ...)
 		local hist = addon.db["combatMeterHistory"]
 		hist[#hist + 1] = fight
 		local MAX = 30
-		if #hist > MAX then table.remove(hist, 1) end
+		while #hist > MAX do
+			table.remove(hist, 1)
+		end
 	elseif event == "COMBAT_LOG_EVENT_UNFILTERED" then
 		if not cm.inCombat then return end
 		local a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25 = CombatLogGetCurrentEventInfo()


### PR DESCRIPTION
## Summary
- limit combat meter history to latest 30 fights

## Testing
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua`
- `stylua --check EnhanceQoLCombatMeter/CombatMeter.lua`

------
https://chatgpt.com/codex/tasks/task_e_689a3b1301e48329a123c0bf3ad144ef