### PR TITLE
Simplify SPELL_ABSORBED handling

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -161,7 +161,6 @@ local function handleEvent(self, event, ...)
 			-- SPELL_ABSORBED has variable arg layouts; the last 8 fields are stable:
 			-- absorberGUID, absorberName, absorberFlags, absorberRaidFlags,
 			-- absorbingSpellID, absorbingSpellName, absorbingSpellSchool, absorbedAmount
-			local a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25 = CombatLogGetCurrentEventInfo()
 			local n = select("#", a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)
 			local absorberGUID = select(n - 7, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)
 			local absorberName = select(n - 6, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)


### PR DESCRIPTION
## Summary
- Avoid redundant event info lookup for SPELL_ABSORBED
- Use `select` to pull absorber fields and absorbed amount

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua`


------
https://chatgpt.com/codex/tasks/task_e_689a3e54c2908329ab932d4bce835e57