### PR TITLE
Handle nil combat log amounts

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -121,7 +121,7 @@ local function handleEvent(self, event, ...)
 		if idx then
 			if not sourceGUID or band(sourceFlags or 0, groupMask) == 0 then return end
 			local amount = select(idx, a12, a13, a14, a15, a16, a17, a18, a19, a20)
-			if amount <= 0 then return end
+			if not amount or amount <= 0 then return end
 			local player = acquirePlayer(cm.players, sourceGUID, sourceName)
 			local overall = acquirePlayer(cm.overallPlayers, sourceGUID, sourceName)
 			player.damage = player.damage + amount
@@ -132,8 +132,8 @@ local function handleEvent(self, event, ...)
 		local hidx = healIdx[subevent]
 		if hidx then
 			if not sourceGUID or band(sourceFlags or 0, groupMask) == 0 then return end
-			local amount = select(hidx[1], a12, a13, a14, a15, a16, a17, a18, a19, a20) - select(hidx[2], a12, a13, a14, a15, a16, a17, a18, a19, a20)
-			if amount <= 0 then return end
+			local amount = (select(hidx[1], a12, a13, a14, a15, a16, a17, a18, a19, a20) or 0) - (select(hidx[2], a12, a13, a14, a15, a16, a17, a18, a19, a20) or 0)
+			if not amount or amount <= 0 then return end
 			local player = acquirePlayer(cm.players, sourceGUID, sourceName)
 			local overall = acquirePlayer(cm.overallPlayers, sourceGUID, sourceName)
 			player.healing = player.healing + amount
@@ -166,14 +166,13 @@ local function handleEvent(self, event, ...)
 			local absorberName = select(n - 6, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)
 			local absorberFlags = select(n - 5, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)
 			if not absorberGUID or band(absorberFlags or 0, groupMask) == 0 then return end
-			local absorbedAmount = select(n, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25) or 0
-			lastAbsorbSourceByDest[destGUID] = absorberGUID
-			if absorbedAmount > 0 then
-				local p = acquirePlayer(cm.players, absorberGUID, absorberName)
-				local o = acquirePlayer(cm.overallPlayers, absorberGUID, absorberName)
-				p.healing = p.healing + absorbedAmount
-				o.healing = o.healing + absorbedAmount
-			end
+                        local amount = select(n, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)
+                        lastAbsorbSourceByDest[destGUID] = absorberGUID
+                        if not amount or amount <= 0 then return end
+                        local p = acquirePlayer(cm.players, absorberGUID, absorberName)
+                        local o = acquirePlayer(cm.overallPlayers, absorberGUID, absorberName)
+                        p.healing = p.healing + amount
+                        o.healing = o.healing + amount
 		end
 	end
 end


### PR DESCRIPTION
## Summary
- Ensure combat log branches safely handle nil `amount` values
- Calculate healing amount with safe subtraction defaults
- Treat absorbed damage as healing only when an amount is present

## Testing
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua`


------
https://chatgpt.com/codex/tasks/task_e_689a3fa8f6e08329950c2ecea4a39b32