### PR TITLE
CombatMeter absorb handling fixes and event guard

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -108,36 +108,33 @@ local function handleCLEU(timestamp, subevent, hideCaster, sourceGUID, sourceNam
 		return
 	end
 
-	if missIdx then
-		local missType = select(missIdx[1], ...)
-		if missType ~= "ABSORB" then return end
-		if not destGUID or band(destFlags or 0, groupMask) == 0 then return end
-		local amount = select(missIdx[2], ...)
-		if not amount or amount <= 0 then return end
-		local absorberGUID = lastAbsorbSourceByDest[destGUID]
-		if not absorberGUID then return end
-		local p = acquirePlayer(cm.players, absorberGUID)
-		local o = acquirePlayer(cm.overallPlayers, absorberGUID)
-		p.healing = p.healing + amount
-		o.healing = o.healing + amount
-		return
-	end
+        if missIdx then
+                local missType = select(missIdx[1], ...)
+                if missType ~= "ABSORB" then return end
+                if not destGUID or band(destFlags or 0, groupMask) == 0 then return end
+                local amount = select(missIdx[2], ...)
+                if not amount or amount <= 0 then return end
+                local info = lastAbsorbSourceByDest[destGUID]
+                local healGUID, healName = (info and info.guid) or destGUID, (info and info.name) or destName
+                local p = acquirePlayer(cm.players, healGUID, healName)
+                local o = acquirePlayer(cm.overallPlayers, healGUID, healName)
+                p.healing = p.healing + amount
+                o.healing = o.healing + amount
+                return
+        end
 
-	if subevent == "SPELL_ABSORBED" then
-		local absorberGUID, absorberName, absorberFlags, absorbedAmount
-		if argc >= 10 then
-			absorberGUID, absorberName, absorberFlags, _, _, _, _, absorbedAmount = select(4, ...)
-		else
-			absorberGUID, absorberName, absorberFlags, _, _, _, _, absorbedAmount = select(argc - 7, ...)
-		end
-		if not absorberGUID or type(absorberFlags) ~= "number" or band(absorberFlags, groupMask) == 0 then return end
-		lastAbsorbSourceByDest[destGUID] = absorberGUID
-		if not absorbedAmount or absorbedAmount <= 0 then return end
-		local p = acquirePlayer(cm.players, absorberGUID, absorberName)
-		local o = acquirePlayer(cm.overallPlayers, absorberGUID, absorberName)
-		p.healing = p.healing + absorbedAmount
-		o.healing = o.healing + absorbedAmount
-	end
+        if subevent == "SPELL_ABSORBED" then
+                local start = argc - 7
+                local absorberGUID, absorberName, absorberFlags, _, _, _, _, absorbedAmount = select(start, ...)
+                if not absorberGUID or type(absorberFlags) ~= "number" or band(absorberFlags, groupMask) == 0 then return end
+                lastAbsorbSourceByDest[destGUID] = { guid = absorberGUID, name = absorberName }
+                if not absorbedAmount or absorbedAmount <= 0 then return end
+                local p = acquirePlayer(cm.players, absorberGUID, absorberName)
+                local o = acquirePlayer(cm.overallPlayers, absorberGUID, absorberName)
+                p.healing = p.healing + absorbedAmount
+                o.healing = o.healing + absorbedAmount
+                return
+        end
 end
 
 local function handleEvent(self, event)
@@ -146,11 +143,12 @@ local function handleEvent(self, event)
 		cm.fightStartTime = GetTime()
 		releasePlayers(cm.players)
 		wipe(lastAbsorbSourceByDest)
-	elseif event == "PLAYER_REGEN_ENABLED" or event == "ENCOUNTER_END" then
-		cm.inCombat = false
-		cm.fightDuration = GetTime() - cm.fightStartTime
-		cm.overallDuration = cm.overallDuration + cm.fightDuration
-		local fight = { duration = cm.fightDuration, players = {} }
+        elseif event == "PLAYER_REGEN_ENABLED" or event == "ENCOUNTER_END" then
+                if not cm.inCombat then return end
+                cm.inCombat = false
+                cm.fightDuration = GetTime() - cm.fightStartTime
+                cm.overallDuration = cm.overallDuration + cm.fightDuration
+                local fight = { duration = cm.fightDuration, players = {} }
 		for guid, data in pairs(cm.players) do
 			fight.players[guid] = {
 				guid = guid,


### PR DESCRIPTION
## Summary
- Prevent fight durations from double-counting when both `ENCOUNTER_END` and `PLAYER_REGEN_ENABLED` fire
- Parse `SPELL_ABSORBED` via last 8 varargs and cache absorber details for missed absorb attribution
- Attribute `_MISSED` absorbs using cached or fallback names to capture healing from full absorbs

## Testing
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a2d707b488329b78eaaae1b5d3a35