### PR TITLE
Cache class colors in CombatMeter UI

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -16,6 +16,7 @@ local specIcons = {}
 local pendingInspect = {}
 local groupFrames = {}
 local groupUnitsCached = {}
+local classByGUID = {}
 local ticker
 
 -- font helpers ---------------------------------------------------------------
@@ -358,9 +359,17 @@ local function createGroupFrame(groupConfig)
 			end
 			bar:SetValue(p.value)
 
-			local _, class = GetPlayerInfoByGUID(p.guid)
-			local color = RAID_CLASS_COLORS[class] or NORMAL_FONT_COLOR
-			bar:SetStatusBarColor(color.r, color.g, color.b)
+			local class = classByGUID[p.guid]
+			if class == nil then
+				local _, c = GetPlayerInfoByGUID(p.guid)
+				class = c or ""
+				classByGUID[p.guid] = class
+			end
+			if bar._class ~= class then
+				local color = RAID_CLASS_COLORS[class] or NORMAL_FONT_COLOR
+				bar:SetStatusBarColor(color.r, color.g, color.b)
+				bar._class = class
+			end
 
 			local unit = groupUnits[p.guid]
 			local icon = specIcons[p.guid]


### PR DESCRIPTION
## Summary
- cache player classes by GUID to reduce repeated `GetPlayerInfoByGUID` calls
- track bar class to avoid redundant status bar color updates

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeterUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_689a53e0951c832993c09d18293dd2de