### PR TITLE
Optimize bar icon updates

### DIFF
--- a/EnhanceQoLAura/CastTracker.lua
+++ b/EnhanceQoLAura/CastTracker.lua
@@ -1137,17 +1137,20 @@ function CastTracker.functions.StartBar(spellId, sourceGUID, catId, overrideCast
 	activeKeyIndex[key] = activeKeyIndex[key] or {}
 	activeKeyIndex[key][catId] = bar
 	activeSourceIndex[sourceGUID] = activeSourceIndex[sourceGUID] or {}
-	activeSourceIndex[sourceGUID][catId] = activeSourceIndex[sourceGUID][catId] or {}
-	activeSourceIndex[sourceGUID][catId][key] = bar
-	bar.sourceGUID = sourceGUID
-	bar.spellId = spellId
-	bar.catId = catId
-	bar.icon:SetTexture(icon)
-	bar.castType = castType or "cast"
-	if spellInfo.customTextEnabled and spellInfo.customText and spellInfo.customText ~= "" then
-		bar.text:SetText(spellInfo.customText)
-	else
-		if altSpellData and altSpellData.name then
+        activeSourceIndex[sourceGUID][catId] = activeSourceIndex[sourceGUID][catId] or {}
+        activeSourceIndex[sourceGUID][catId][key] = bar
+        bar.sourceGUID = sourceGUID
+        bar.spellId = spellId
+        bar.catId = catId
+        if bar._icon ~= icon then
+                bar.icon:SetTexture(icon)
+                bar._icon = icon
+        end
+        bar.castType = castType or "cast"
+        if spellInfo.customTextEnabled and spellInfo.customText and spellInfo.customText ~= "" then
+                bar.text:SetText(spellInfo.customText)
+        else
+                if altSpellData and altSpellData.name then
 			bar.text:SetText(altSpellData.name)
 		else
 			bar.text:SetText(name)


### PR DESCRIPTION
## Summary
- Cache last icon for bars to avoid redundant `SetTexture` calls
- Gate `NotifyInspect` calls behind `CanInspect` and pending state

## Testing
- `luacheck EnhanceQoLAura/CastTracker.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_689a5513d6c08329ae7cd31557152e86