### PR TITLE
Prune caches after roster updates

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -2,7 +2,7 @@ local parentAddonName = "EnhanceQoL"
 local addonName, addon = ...
 if _G[parentAddonName] then
 	addon = _G[parentAddonName]
-else
+	else
 	error(parentAddonName .. " is not loaded")
 end
 
@@ -528,10 +528,16 @@ controller:SetScript("OnEvent", function(self, event, ...)
 	elseif event == "GROUP_ROSTER_UPDATE" then
 		buildGroupUnits()
 		for guid in pairs(specIcons) do
-			if not groupUnitsCached[guid] then
-				specIcons[guid] = nil
-				pendingInspect[guid] = nil
-			end
+			if not groupUnitsCached[guid] then specIcons[guid] = nil end
+		end
+		for guid in pairs(pendingInspect) do
+			if not groupUnitsCached[guid] then pendingInspect[guid] = nil end
+		end
+		for guid in pairs(classByGUID) do
+			if not groupUnitsCached[guid] then classByGUID[guid] = nil end
+		end
+		for guid in pairs(shortNameCache) do
+			if not groupUnitsCached[guid] then shortNameCache[guid] = nil end
 		end
 		C_Timer.After(0, UpdateAllFrames)
 	else


### PR DESCRIPTION
## Summary
- Clear outdated specialization icons, pending inspect requests, class cache, and short name cache when the group roster changes

## Testing
- `luac -p EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeterUI.lua`

------
https://chatgpt.com/codex/tasks/task_e_689a5986b2508329a01cc78520bea003