### PR TITLE
Ensure group unit rebuild before ticker

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -494,8 +494,8 @@ addon.CombatMeter.uiFrame = controller
 
 controller:SetScript("OnEvent", function(self, event, ...)
 	if event == "PLAYER_REGEN_DISABLED" or event == "ENCOUNTER_START" then
-		buildGroupUnits()
 		if ticker then ticker:Cancel() end
+		buildGroupUnits()
 		ticker = C_Timer.NewTicker(config["combatMeterUpdateRate"], UpdateAllFrames)
 		addon.CombatMeter.ticker = ticker
 		C_Timer.After(0, UpdateAllFrames)


### PR DESCRIPTION
## Summary
- Rebuild combat meter group unit cache before ticker starts on combat begin events

## Testing
- `luacheck EnhanceQoLCombatMeter/CombatMeterUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_689ab197201c8329a5e479c567c26adf