### PR TITLE
Move SPELL_ABSORBED argc calculation inside handler

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -71,7 +71,6 @@ local healIdx = {
 }
 
 local function handleCLEU(timestamp, subevent, hideCaster, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, ...)
-	local argc = select("#", ...)
 	-- Note: We intentionally ignore *_MISSED ABSORB to avoid double-counting with SPELL_ABSORBED (matches Details behavior)
 	if not (dmgIdx[subevent] or healIdx[subevent] or subevent == "SPELL_ABSORBED") then return end
 
@@ -105,6 +104,7 @@ local function handleCLEU(timestamp, subevent, hideCaster, sourceGUID, sourceNam
 		-- absorberGUID, absorberName, absorberFlags, absorberRaidFlags,
 		-- absorbingSpellID, absorbingSpellName, absorbingSpellSchool,
 		-- absorbedAmount, absorbedCritical
+		local argc = select("#", ...)
 		local start = argc - 8
 		local absorberGUID, absorberName, absorberFlags, _, spellName, _, _, absorbedAmount, absorbedCritical = select(start, ...)
 		if not absorberGUID or type(absorberFlags) ~= "number" or band(absorberFlags, groupMask) == 0 then return end


### PR DESCRIPTION
## Summary
- compute SPELL_ABSORBED argument count within block

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua`


------
https://chatgpt.com/codex/tasks/task_e_689abe63f5c48329ab6166f367937eda