### PR TITLE
Expose overall combat stats for direct UI access

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -209,20 +209,9 @@ end
 frame:SetScript("OnEvent", handleEvent)
 
 function cm.functions.getOverallStats()
-	local duration = cm.overallDuration
-	if duration <= 0 then duration = 1 end
-	local results = {}
-	for guid, data in pairs(cm.overallPlayers) do
-		results[guid] = {
-			guid = guid,
-			name = data.name,
-			damage = data.damage,
-			healing = data.healing,
-			dps = data.damage / duration,
-			hps = data.healing / duration,
-		}
-	end
-	return results, duration
+        local duration = cm.overallDuration
+        if duration <= 0 then duration = 1 end
+        return cm.overallPlayers, duration
 end
 
 function cm.functions.toggle(enabled)

--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -259,19 +259,18 @@ local function createGroupFrame(groupConfig)
 		self:Show()
 		local list = {}
 		local maxValue = 0
-		if self.metric == "damageOverall" or self.metric == "healingOverall" then
-			local stats = addon.CombatMeter.functions.getOverallStats()
-			local dur = (addon.CombatMeter.functions.getOverallDuration and addon.CombatMeter.functions.getOverallDuration()) or addon.CombatMeter.overallDuration or 0
-			if dur <= 0 then dur = 1 end
-			for guid, p in pairs(stats) do
-				if groupUnits[guid] then
-					local total = (self.metric == "damageOverall") and (p.damage or 0) or (p.healing or 0)
-					local value = total / dur -- rate over total tracked time
-					tinsert(list, { guid = guid, name = p.name, value = value, total = total })
-					if value > maxValue then maxValue = value end
-				end
-			end
-		else
+                        if self.metric == "damageOverall" or self.metric == "healingOverall" then
+                                local stats, dur = addon.CombatMeter.functions.getOverallStats()
+                                if dur <= 0 then dur = 1 end
+                                for guid, p in pairs(stats) do
+                                        if groupUnits[guid] then
+                                                local total = (self.metric == "damageOverall") and (p.damage or 0) or (p.healing or 0)
+                                                local value = total / dur -- rate over total tracked time
+                                                tinsert(list, { guid = guid, name = p.name, value = value, total = total })
+                                                if value > maxValue then maxValue = value end
+                                        end
+                                end
+                        else
 			local duration
 			if addon.CombatMeter.inCombat then
 				duration = GetTime() - addon.CombatMeter.fightStartTime
@@ -331,20 +330,19 @@ local function createGroupFrame(groupConfig)
 				end
 			end
 			if not found then
-				local name = UnitName("player")
-				local value, total
-				if self.metric == "damageOverall" or self.metric == "healingOverall" then
-					local stats = addon.CombatMeter.functions.getOverallStats()
-					local dur = (addon.CombatMeter.functions.getOverallDuration and addon.CombatMeter.functions.getOverallDuration()) or addon.CombatMeter.overallDuration or 0
-					if dur <= 0 then dur = 1 end
-					local p = stats[playerGUID]
-					if p then
-						total = (self.metric == "damageOverall") and (p.damage or 0) or (p.healing or 0)
-					else
-						total = 0
-					end
-					value = total / dur
-				else
+                               local name = UnitName("player")
+                               local value, total
+                               if self.metric == "damageOverall" or self.metric == "healingOverall" then
+                                       local stats, dur = addon.CombatMeter.functions.getOverallStats()
+                                       if dur <= 0 then dur = 1 end
+                                       local p = stats[playerGUID]
+                                       if p then
+                                               total = (self.metric == "damageOverall") and (p.damage or 0) or (p.healing or 0)
+                                       else
+                                               total = 0
+                                       end
+                                       value = total / dur
+                               else
 					local duration
 					if addon.CombatMeter.inCombat then
 						duration = GetTime() - addon.CombatMeter.fightStartTime


### PR DESCRIPTION
## Summary
- Return `cm.overallPlayers` and duration from `getOverallStats`
- Update combat meter UI to use returned table and calculate DPS/HPS on demand

## Testing
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_689ac28b784483298225dd752c9f633e