### PR TITLE
Remove duplicate Combat Meter toggle call

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -258,8 +258,6 @@ function cm.functions.toggle(enabled)
 	end
 end
 
-cm.functions.toggle(addon.db["combatMeterEnabled"])
-
 SLASH_EQOLCM1 = "/eqolcm"
 SlashCmdList["EQOLCM"] = function(msg)
 	if msg == "reset" then


### PR DESCRIPTION
## Summary
- Centralize Combat Meter initialization by letting CombatMeterUI handle the initial `toggle` call
- Remove redundant `toggle` invocation from CombatMeter core module

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua` *(fails: accessing undefined variable COMBATLOG_OBJECT_TYPE_TOTEM, COMBATLOG_OBJECT_TYPE_VEHICLE)*

------
https://chatgpt.com/codex/tasks/task_e_689ac71c11548329bf0610c127281fca