### PR TITLE
Refactor overall combat stats retrieval

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -214,12 +214,6 @@ end
 
 frame:SetScript("OnEvent", handleEvent)
 
-function cm.functions.getOverallStats()
-	local duration = cm.overallDuration
-	if duration <= 0 then duration = 1 end
-	return cm.overallPlayers, duration
-end
-
 function cm.functions.toggle(enabled)
 	if enabled then
 		frame:RegisterEvent("PLAYER_REGEN_DISABLED")

--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -259,21 +259,21 @@ local function createGroupFrame(groupConfig)
 		self:Show()
 		local list = {}
 		local maxValue = 0
-                        if self.metric == "damageOverall" or self.metric == "healingOverall" then
-                                local stats, dur = addon.CombatMeter.functions.getOverallStats()
-                                if dur <= 0 then dur = 1 end
-                                for guid, p in pairs(stats) do
-                                        if groupUnits[guid] then
-                                                local total = (self.metric == "damageOverall") and (p.damage or 0) or (p.healing or 0)
-                                                local value = total / dur -- rate over total tracked time
-                                                tinsert(list, { guid = guid, name = p.name, value = value, total = total })
-                                                if value > maxValue then maxValue = value end
-                                        end
-                                end
-                        else
-			local duration
-			if addon.CombatMeter.inCombat then
-				duration = GetTime() - addon.CombatMeter.fightStartTime
+               if self.metric == "damageOverall" or self.metric == "healingOverall" then
+                       local duration = addon.CombatMeter.overallDuration
+                       if duration <= 0 then duration = 1 end
+                       for guid, p in pairs(addon.CombatMeter.overallPlayers) do
+                               if groupUnits[guid] then
+                                       local total = (self.metric == "damageOverall") and (p.damage or 0) or (p.healing or 0)
+                                       local value = total / duration -- rate over total tracked time
+                                       tinsert(list, { guid = guid, name = p.name, value = value, total = total })
+                                       if value > maxValue then maxValue = value end
+                               end
+                       end
+               else
+                       local duration
+                       if addon.CombatMeter.inCombat then
+                               duration = GetTime() - addon.CombatMeter.fightStartTime
 			else
 				duration = addon.CombatMeter.fightDuration
 			end
@@ -333,19 +333,19 @@ local function createGroupFrame(groupConfig)
                                local name = UnitName("player")
                                local value, total
                                if self.metric == "damageOverall" or self.metric == "healingOverall" then
-                                       local stats, dur = addon.CombatMeter.functions.getOverallStats()
-                                       if dur <= 0 then dur = 1 end
-                                       local p = stats[playerGUID]
+                                       local duration = addon.CombatMeter.overallDuration
+                                       if duration <= 0 then duration = 1 end
+                                       local p = addon.CombatMeter.overallPlayers[playerGUID]
                                        if p then
                                                total = (self.metric == "damageOverall") and (p.damage or 0) or (p.healing or 0)
                                        else
                                                total = 0
                                        end
-                                       value = total / dur
+                                       value = total / duration
                                else
-					local duration
-					if addon.CombatMeter.inCombat then
-						duration = GetTime() - addon.CombatMeter.fightStartTime
+                                       local duration
+                                       if addon.CombatMeter.inCombat then
+                                               duration = GetTime() - addon.CombatMeter.fightStartTime
 					else
 						duration = addon.CombatMeter.fightDuration
 					end


### PR DESCRIPTION
## Summary
- remove `getOverallStats` helper
- inline overall player iteration and rate computation

## Testing
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`

------
https://chatgpt.com/codex/tasks/task_e_689ac90fac308329bae98b4fceb5c8c9