### PR TITLE
refactor: centralize combat meter value sorting

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -21,6 +21,8 @@ local shortNameCache = {}
 local ticker
 local tinsert, tsort = table.insert, table.sort
 
+local function sortByValueDesc(a, b) return a.value > b.value end
+
 local function scheduleInspectRetry(guid, unit)
 	C_Timer.After(1, function()
 		if pendingInspect[guid] and CanInspect(unit) then NotifyInspect(unit) end
@@ -320,7 +322,7 @@ local function createGroupFrame(groupConfig)
 			end
 			list = top
 		else
-			tsort(list, function(a, b) return a.value > b.value end)
+			tsort(list, sortByValueDesc)
 		end
 		local playerGUID = UnitGUID("player")
 		if groupConfig.alwaysShowSelf then


### PR DESCRIPTION
## Summary
- define reusable `sortByValueDesc` comparator
- apply comparator in combat meter list sorting

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeterUI.lua`

------
https://chatgpt.com/codex/tasks/task_e_689acd1b7e088329afdb85896a02388d