### PR TITLE
Refresh cached short names when player name changes

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -109,10 +109,10 @@ local function createGroupFrame(groupConfig)
 	local barWidth = groupConfig.barWidth or DEFAULT_BAR_WIDTH
 	local frameWidth = barWidth + barHeight + 2
 
-        local frame = CreateFrame("Frame", nil, UIParent, "BackdropTemplate")
-        frame:SetSize(frameWidth, barHeight)
-        frame._h = barHeight
-        frame:SetMovable(true)
+	local frame = CreateFrame("Frame", nil, UIParent, "BackdropTemplate")
+	frame:SetSize(frameWidth, barHeight)
+	frame._h = barHeight
+	frame:SetMovable(true)
 	frame:EnableMouse(true)
 	frame:SetClampedToScreen(true)
 	frame:Hide()
@@ -433,7 +433,7 @@ local function createGroupFrame(groupConfig)
 			end
 
 			local shortName = shortNameCache[p.guid]
-			if not shortName then
+			if not shortName or p.name ~= shortName then
 				shortName = abbreviateName(p.name)
 				shortNameCache[p.guid] = shortName
 			end
@@ -468,16 +468,16 @@ local function createGroupFrame(groupConfig)
 			end
 		end
 
-                for i = displayCount + 1, #self.bars do
-                        self.bars[i]:Hide()
-                end
+		for i = displayCount + 1, #self.bars do
+			self.bars[i]:Hide()
+		end
 
-                local newHeight = 16 + displayCount * barHeight
-                if self._h ~= newHeight then
-                        self:SetHeight(newHeight)
-                        self._h = newHeight
-                end
-        end
+		local newHeight = 16 + displayCount * barHeight
+		if self._h ~= newHeight then
+			self:SetHeight(newHeight)
+			self._h = newHeight
+		end
+	end
 
 	return frame
 end


### PR DESCRIPTION
## Summary
- Recompute cached abbreviated names when player names change during frame updates

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeterUI.lua` (2 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689ad02576148329809f9bcc1307af28