### PR TITLE
Use direct SetTextColor for combat meter rate column

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -233,7 +233,7 @@ local function createGroupFrame(groupConfig)
 			bar.name:SetTextColor(1, 1, 1)
 			bar.value:SetTextColor(1, 1, 1)
 			bar.total:SetTextColor(1, 1, 1)
-			bar.rate.SetTextColor = bar.value.SetTextColor -- keep API parity if needed
+			bar.rate:SetTextColor(1, 1, 1)
 
 			local size = config["combatMeterFontSize"]
 			local outline = getOutlineFlags()


### PR DESCRIPTION
## Summary
- remove SetTextColor aliasing for rate column and set its color directly

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeterUI.lua`

------
https://chatgpt.com/codex/tasks/task_e_689ad7cbbb5483298a5eeb4f4ac33f24