### PR TITLE
fix: cache player name from GUID in CombatMeter

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -33,14 +33,14 @@ local function resolveOwner(srcGUID, srcName, srcFlags)
 		local owner = petOwner[srcGUID]
 		if owner then
 			if not ownerNameCache[owner] then
-				local oname = GetPlayerInfoByGUID(owner)
+				local oname = select(6, GetPlayerInfoByGUID(owner))
 				if oname then ownerNameCache[owner] = oname end
 			end
 			return owner, (ownerNameCache[owner] or srcName)
 		end
 	end
 	if srcGUID and not ownerNameCache[srcGUID] then
-		local sname = GetPlayerInfoByGUID(srcGUID)
+		local sname = select(6, GetPlayerInfoByGUID(srcGUID))
 		if sname then ownerNameCache[srcGUID] = sname end
 	end
 	return srcGUID, (ownerNameCache[srcGUID] or srcName)


### PR DESCRIPTION
## Summary
- ensure CombatMeter caches player names from GUID lookups

## Testing
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua`


------
https://chatgpt.com/codex/tasks/task_e_689ae004e0f0832999df7b00db2cdd25