### PR TITLE
refactor: remove unused spell name

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -200,7 +200,7 @@ local function handleEvent(self, event)
 			local absorberGUID = info[base]
 			local absorberName = info[base + 1]
 			local absorberFlags = info[base + 2]
-			local spellName = info[base + 4]
+			-- info[base + 4] holds the absorbing spell name if needed for debugging
 			local absorbedAmount = info[base + 7]
 			local absorbedCritical = info[base + 8]
 			if not absorberGUID or type(absorberFlags) ~= "number" or band(absorberFlags, groupMask) == 0 then return end


### PR DESCRIPTION
## Summary
- clean up unused spellName variable in combat meter

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua`


------
https://chatgpt.com/codex/tasks/task_e_689ae349c2f48329a3bd512c6489bd9c