### PR TITLE
refactor: avoid wipe in combat meter

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -74,46 +74,50 @@ local function releasePlayers(players)
 	local pool = cm.playerPool
 	for guid in pairs(players) do
 		local player = players[guid]
-		wipe(player)
+		player.damage = 0
+		player.healing = 0
+		player.name = nil
+		player.class = nil
+		player.guid = nil
 		pool[#pool + 1] = player
 		players[guid] = nil
 	end
 end
 
 local function fullRebuildPetOwners()
-        wipe(petOwner)
-        local activeGUIDs = {}
-        if IsInRaid() then
-                for i = 1, GetNumGroupMembers() do
-                        local owner = UnitGUID("raid" .. i)
-                        local pguid = UnitGUID("raid" .. i .. "pet")
-                        if owner then activeGUIDs[owner] = true end
-                        if owner and pguid then
-                                petOwner[pguid] = owner
-                                activeGUIDs[pguid] = true
-                        end
-                end
-        else
-                for i = 1, GetNumGroupMembers() do
-                        local owner = UnitGUID("party" .. i)
-                        local pguid = UnitGUID("party" .. i .. "pet")
-                        if owner then activeGUIDs[owner] = true end
-                        if owner and pguid then
-                                petOwner[pguid] = owner
-                                activeGUIDs[pguid] = true
-                        end
-                end
-                local me = UnitGUID("player")
-                local mypet = UnitGUID("pet")
-                if me then activeGUIDs[me] = true end
-                if me and mypet then
-                        petOwner[mypet] = me
-                        activeGUIDs[mypet] = true
-                end
-        end
-        for guid in pairs(ownerNameCache) do
-                if not activeGUIDs[guid] then ownerNameCache[guid] = nil end
-        end
+	wipe(petOwner)
+	local activeGUIDs = {}
+	if IsInRaid() then
+		for i = 1, GetNumGroupMembers() do
+			local owner = UnitGUID("raid" .. i)
+			local pguid = UnitGUID("raid" .. i .. "pet")
+			if owner then activeGUIDs[owner] = true end
+			if owner and pguid then
+				petOwner[pguid] = owner
+				activeGUIDs[pguid] = true
+			end
+		end
+	else
+		for i = 1, GetNumGroupMembers() do
+			local owner = UnitGUID("party" .. i)
+			local pguid = UnitGUID("party" .. i .. "pet")
+			if owner then activeGUIDs[owner] = true end
+			if owner and pguid then
+				petOwner[pguid] = owner
+				activeGUIDs[pguid] = true
+			end
+		end
+		local me = UnitGUID("player")
+		local mypet = UnitGUID("pet")
+		if me then activeGUIDs[me] = true end
+		if me and mypet then
+			petOwner[mypet] = me
+			activeGUIDs[mypet] = true
+		end
+	end
+	for guid in pairs(ownerNameCache) do
+		if not activeGUIDs[guid] then ownerNameCache[guid] = nil end
+	end
 end
 
 local function updatePetOwner(unit)


### PR DESCRIPTION
## Summary
- replace `wipe(player)` with explicit field resets in CombatMeter

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua`

------
https://chatgpt.com/codex/tasks/task_e_689b53d882a88329b484f6e01a870c79