### PR TITLE
Avoid duplicate combat start events

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -182,6 +182,7 @@ local dmgIdx = {
 
 local function handleEvent(self, event, unit)
 	if event == "PLAYER_REGEN_DISABLED" or event == "ENCOUNTER_START" then
+		if cm.inCombat then return end
 		cm.inCombat = true
 		cm.fightStartTime = GetTime()
 		cm.historySelection = nil


### PR DESCRIPTION
## Summary
- guard against duplicate combat start events

## Testing
- `luac -p EnhanceQoLCombatMeter/CombatMeter.lua`
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua`


------
https://chatgpt.com/codex/tasks/task_e_689baa78896c832982f16968bf8a8493