### PR TITLE
refactor: wipe player on release

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -81,11 +81,7 @@ local function releasePlayers(players)
 	local pool = cm.playerPool
 	for guid in pairs(players) do
 		local player = players[guid]
-		player.damage = 0
-		player.healing = 0
-		player.name = nil
-		player.class = nil
-		player.guid = nil
+		wipe(player)
 		pool[#pool + 1] = player
 		players[guid] = nil
 	end


### PR DESCRIPTION
## Summary
- streamline releasePlayers by wiping player objects before pooling

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua` *(fails: accessing undefined variables COMBATLOG_OBJECT_TYPE_TOTEM, COMBATLOG_OBJECT_TYPE_VEHICLE)*

------
https://chatgpt.com/codex/tasks/task_e_689c0a20a4808329801626c33c7bf899