### PR TITLE
feat: gold tinted history icon

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -345,7 +345,8 @@ local function createGroupFrame(groupConfig)
 	historyButton.icon = historyButton:CreateTexture(nil, "ARTWORK")
 	historyButton.icon:SetAllPoints(historyButton)
 	historyButton.icon:SetTexture(TEXTURE_PATH .. "eqol_history_64.tga")
-	historyButton.icon:SetVertexColor(1, 0.85, 0)
+	-- Tint the history icon in gold
+	historyButton.icon:SetVertexColor(1, 0.82, 0)
 
 	local hhl = historyButton:CreateTexture(nil, "HIGHLIGHT")
 	hhl:SetAllPoints(historyButton)
@@ -353,10 +354,10 @@ local function createGroupFrame(groupConfig)
 	hhl:SetBlendMode("ADD")
 
 	historyButton:SetScript("OnMouseDown", function(self)
-		if self.icon then self.icon:SetVertexColor(0.9, 0.77, 0) end
+		if self.icon then self.icon:SetVertexColor(0.9, 0.74, 0) end
 	end)
 	historyButton:SetScript("OnMouseUp", function(self)
-		if self.icon then self.icon:SetVertexColor(1, 0.85, 0) end
+		if self.icon then self.icon:SetVertexColor(1, 0.82, 0) end
 	end)
 
 	historyButton:SetScript("OnClick", function(self) OpenHistoryMenu(self) end)


### PR DESCRIPTION
## Summary
- tint CombatMeter's history button gold using new eqol_history_64.tga icon

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeterUI.lua` *(fails: accessing undefined variable NumberFontNormal)*

------
https://chatgpt.com/codex/tasks/task_e_689c10cf61cc832989da5bbdd8988626