### PR TITLE
Separate Taza dungeon segments in rating

### DIFF
--- a/EnhanceQoLMythicPlus/DungeonPortal.lua
+++ b/EnhanceQoLMythicPlus/DungeonPortal.lua
@@ -79,15 +79,27 @@ local function getCurrentSeasonPortal()
 					if cModeIDLookup[cId] then
 						local mapName, _, _, texture, backgroundTexture = C_ChallengeMode.GetMapUIInfo(cId)
 
+						local displayText = data.text
+						if type(displayText) == "table" then
+							local texts = {}
+							for _, txt in pairs(displayText) do
+								table.insert(texts, txt)
+							end
+							table.sort(texts)
+							displayText = table.concat(texts, "/")
+						end
+
 						filteredPortalSpells[spellID] = {
-							text = data.text,
+							text = displayText,
 							iconID = data.iconID,
 						}
 						if data.faction then
 							filteredPortalSpells[spellID].faction = data.faction
 							if data.faction == faction then
+								local mapText = data.text
+								if type(mapText) == "table" then mapText = mapText[cId] end
 								filteredMapInfo[cId] = {
-									text = data.text,
+									text = mapText,
 									spellId = spellID,
 									mapName = mapName,
 									texture = texture,
@@ -95,8 +107,10 @@ local function getCurrentSeasonPortal()
 								}
 							end
 						else
+							local mapText = data.text
+							if type(mapText) == "table" then mapText = mapText[cId] end
 							filteredMapInfo[cId] = {
-								text = data.text,
+								text = mapText,
 								spellId = spellID,
 								mapName = mapName,
 								texture = texture,

--- a/EnhanceQoLMythicPlus/Init.lua
+++ b/EnhanceQoLMythicPlus/Init.lua
@@ -454,7 +454,7 @@ addon.MythicPlus.variables.portalCompendium = {
 			[354468] = { text = "DOS", cId = { [377] = true } },
 			[354469] = { text = "SD", cId = { [380] = true } },
 			[367416] = {
-				text = "TAZA",
+				text = { [391] = "STREET", [392] = "GAMBIT" },
 				cId = { [391] = true, [392] = true },
 				mapID = { [391] = { mapID = 2441, zoneID = 1989 }, [392] = { mapID = 2441, zoneID = 1995 } }, -- Checks for zoneID + mapID for Mega Dungeons
 			},


### PR DESCRIPTION
## Summary
- distinguish Tazavesh Street and Gambit by challenge ID
- support table-based text lookups for multi-part dungeons

## Testing
- `stylua EnhanceQoLMythicPlus/Init.lua EnhanceQoLMythicPlus/DungeonPortal.lua`
- `luacheck EnhanceQoLMythicPlus/Init.lua EnhanceQoLMythicPlus/DungeonPortal.lua`


------
https://chatgpt.com/codex/tasks/task_e_689c58c6687083298355364c37d6afab