### PR TITLE
Track per-player active time for overall metrics

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -470,13 +470,11 @@ local function createGroupFrame(groupConfig)
 		wipe(list)
 		wipe(top)
 		local maxValue = 0
-		local overallDuration = addon.CombatMeter.overallDuration
-		if overallDuration <= 0 then overallDuration = 1 end
 		if self.metric == "damageOverall" or self.metric == "healingOverall" then
 			for guid, p in pairs(addon.CombatMeter.overallPlayers) do
 				if groupUnits[guid] then
 					local total = (self.metric == "damageOverall") and (p.damage or 0) or (p.healing or 0)
-					local value = total / overallDuration -- rate over total tracked time
+					local value = total / math.max(p.time or 0, 1)
 					tinsert(list, { guid = guid, name = p.name, value = value, total = total, class = p.class })
 					if value > maxValue then maxValue = value end
 				end
@@ -544,10 +542,11 @@ local function createGroupFrame(groupConfig)
 					if p then
 						total = (self.metric == "damageOverall") and (p.damage or 0) or (p.healing or 0)
 						class = p.class
+						value = total / math.max(p.time or 0, 1)
 					else
 						total = 0
+						value = 0
 					end
-					value = total / overallDuration
 				else
 					local duration
 					if addon.CombatMeter.inCombat then


### PR DESCRIPTION
## Summary
- accumulate fight duration per player into overall totals
- base overall DPS/HPS on each player's active time instead of global duration

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`

------
https://chatgpt.com/codex/tasks/task_e_689ce02eb7a4832985a0c42717d77e6b