### PR TITLE
fix: avoid AddStream recreating deleted datapanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### 🐛 Fixed
+
+- Prevent `DataPanel.AddStream` from recreating deleted panels.
+
 ## [4.4.0] – 2025-08-14
 
 ### ✨ Added

--- a/EnhanceQoL/Core/DataPanel.lua
+++ b/EnhanceQoL/Core/DataPanel.lua
@@ -260,8 +260,8 @@ end
 
 function DataPanel.AddStream(id, name)
 	id = tostring(id)
-	local panel = DataPanel.Create(id)
-	panel:AddStream(name)
+	local panel = panels[id] or panels[tonumber(id)]
+	if panel then panel:AddStream(name) end
 end
 
 function DataPanel.RemoveStream(id, name)


### PR DESCRIPTION
## Summary
- stop `DataPanel.AddStream` from automatically creating panels
- document fix in changelog

## Testing
- `stylua EnhanceQoL/Core/DataPanel.lua`
- `luacheck EnhanceQoL/Core/DataPanel.lua`


------
https://chatgpt.com/codex/tasks/task_e_689db1a31f908329966c853af3a195f3