### PR TITLE
Ensure per-fight spell tables are reused

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -93,6 +93,7 @@ local function acquirePlayer(tbl, guid, name)
 		players[guid] = player
 	end
 	if name and player.name ~= name then player.name = name end
+	player.spells = player.spells or {}
 	return player
 end
 
@@ -100,7 +101,10 @@ local function releasePlayers(players)
 	local pool = cm.playerPool
 	for guid in pairs(players) do
 		local player = players[guid]
+		local spells = player.spells
+		if spells then wipe(spells) end
 		wipe(player)
+		player.spells = spells
 		pool[#pool + 1] = player
 		players[guid] = nil
 	end


### PR DESCRIPTION
## Summary
- Initialize a spells table for players when acquired so per-fight data is available
- Clean up and preserve the spells table when releasing players back to the pool

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua`


------
https://chatgpt.com/codex/tasks/task_e_689dc786c5c48329a1a744246ae76fe9