### PR TITLE
Capture pre-combat spell metadata in CombatMeter

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -225,7 +225,7 @@ local function updatePetOwner(unit)
 	end
 end
 
-local function addPrePull(ownerGUID, ownerName, damage, healing, sid, sname, crit)
+local function addPrePull(ownerGUID, ownerName, damage, healing, spellId, spellName, crit)
 	local buf = cm.prePullBuffer
 	local now = GetTime()
 	local tail = cm.prePullTail + 1
@@ -235,8 +235,8 @@ local function addPrePull(ownerGUID, ownerName, damage, healing, sid, sname, cri
 		name = ownerName,
 		damage = damage or 0,
 		healing = healing or 0,
-		sid = sid,
-		sname = sname,
+                spellId = spellId,
+                spellName = spellName,
 		crit = crit,
 	}
 	cm.prePullTail = tail
@@ -261,65 +261,65 @@ local function mergePrePull()
 	local head = cm.prePullHead
 	local tail = cm.prePullTail
 	if not buf or head > tail then return end
-	local cutoff = GetTime() - (addon.db["combatMeterPrePullWindow"] or 4)
-	for i = head, tail do
-		local e = buf[i]
-		if e and e.t >= cutoff then
-			local ownerGUID, ownerName = resolveOwner(e.guid, e.name, unitAffiliation[e.guid])
-			e.guid = ownerGUID
-			e.name = ownerName
-			local p = acquirePlayer(cm.players, ownerGUID, ownerName)
-			p._first = p._first or e.t
-			p._last = e.t
-			local o = acquirePlayer(cm.overallPlayers, ownerGUID, ownerName)
-			local sid = e.sid or -1
-			local sname = e.sname or "Other"
-			if e.damage and e.damage > 0 then
-				p.damage = p.damage + e.damage
-				o.damage = o.damage + e.damage
-				local ps = p.spells[sid]
-				if not ps then
-					ps = { name = sname, amount = 0, hits = 0, crits = 0 }
-					p.spells[sid] = ps
-				end
-				ps.name = sname
-				ps.amount = ps.amount + e.damage
-				ps.hits = (ps.hits or 0) + 1
-				if e.crit then ps.crits = (ps.crits or 0) + 1 end
-				local os = o.spells[sid]
-				if not os then
-					os = { name = sname, amount = 0, hits = 0, crits = 0 }
-					o.spells[sid] = os
-				end
-				os.name = sname
-				os.amount = os.amount + e.damage
-				os.hits = (os.hits or 0) + 1
-				if e.crit then os.crits = (os.crits or 0) + 1 end
-			end
-			if e.healing and e.healing > 0 then
-				p.healing = p.healing + e.healing
-				o.healing = o.healing + e.healing
-				local ps = p.spells[sid]
-				if not ps then
-					ps = { name = sname, amount = 0, hits = 0, crits = 0 }
-					p.spells[sid] = ps
-				end
-				ps.name = sname
-				ps.amount = ps.amount + e.healing
-				ps.hits = (ps.hits or 0) + 1
-				if e.crit then ps.crits = (ps.crits or 0) + 1 end
-				local os = o.spells[sid]
-				if not os then
-					os = { name = sname, amount = 0, hits = 0, crits = 0 }
-					o.spells[sid] = os
-				end
-				os.name = sname
-				os.amount = os.amount + e.healing
-				os.hits = (os.hits or 0) + 1
-				if e.crit then os.crits = (os.crits or 0) + 1 end
-			end
-		end
-	end
+        local cutoff = GetTime() - (addon.db["combatMeterPrePullWindow"] or 4)
+        for i = head, tail do
+                local e = buf[i]
+                if e and e.t >= cutoff then
+                        local ownerGUID, ownerName = resolveOwner(e.guid, e.name, unitAffiliation[e.guid])
+                        e.guid = ownerGUID
+                        e.name = ownerName
+                        local p = acquirePlayer(cm.players, ownerGUID, ownerName)
+                        p._first = p._first or e.t
+                        p._last = e.t
+                        local o = acquirePlayer(cm.overallPlayers, ownerGUID, ownerName)
+                        local sid = e.spellId or -1
+                        local sname = e.spellName or "Other"
+                        if e.damage and e.damage > 0 then
+                                local ps = p.spells[sid]
+                                if not ps then
+                                        ps = { name = sname, amount = 0, hits = 0, crits = 0 }
+                                        p.spells[sid] = ps
+                                end
+                                ps.name = sname
+                                ps.amount = ps.amount + e.damage
+                                ps.hits = (ps.hits or 0) + 1
+                                if e.crit then ps.crits = (ps.crits or 0) + 1 end
+                                local os = o.spells[sid]
+                                if not os then
+                                        os = { name = sname, amount = 0, hits = 0, crits = 0 }
+                                        o.spells[sid] = os
+                                end
+                                os.name = sname
+                                os.amount = os.amount + e.damage
+                                os.hits = (os.hits or 0) + 1
+                                if e.crit then os.crits = (os.crits or 0) + 1 end
+                                p.damage = p.damage + e.damage
+                                o.damage = o.damage + e.damage
+                        end
+                        if e.healing and e.healing > 0 then
+                                local ps = p.spells[sid]
+                                if not ps then
+                                        ps = { name = sname, amount = 0, hits = 0, crits = 0 }
+                                        p.spells[sid] = ps
+                                end
+                                ps.name = sname
+                                ps.amount = ps.amount + e.healing
+                                ps.hits = (ps.hits or 0) + 1
+                                if e.crit then ps.crits = (ps.crits or 0) + 1 end
+                                local os = o.spells[sid]
+                                if not os then
+                                        os = { name = sname, amount = 0, hits = 0, crits = 0 }
+                                        o.spells[sid] = os
+                                end
+                                os.name = sname
+                                os.amount = os.amount + e.healing
+                                os.hits = (os.hits or 0) + 1
+                                if e.crit then os.crits = (os.crits or 0) + 1 end
+                                p.healing = p.healing + e.healing
+                                o.healing = o.healing + e.healing
+                        end
+                end
+        end
 	cm.prePullHead = 1
 	cm.prePullTail = 0
 	wipe(buf)
@@ -435,39 +435,39 @@ local function handleEvent(self, event, unit)
 			if band(ownerFlags or 0, groupMask) == 0 then return end
 			local amount = (idx == 1 and a12) or a15 or 0
 			if amount <= 0 then return end
-			local sid, sname = getSpellInfoFromSub(sub, a12, a15)
-			local crit = a21 or a18
-			if inCombat then
-				local player = acquirePlayer(cm.players, ownerGUID, ownerName)
-				local overall = acquirePlayer(cm.overallPlayers, ownerGUID, ownerName)
+                        local spellId, spellName = getSpellInfoFromSub(sub, a12, a15)
+                        local crit = a21 or a18
+                        if inCombat then
+                                local player = acquirePlayer(cm.players, ownerGUID, ownerName)
+                                local overall = acquirePlayer(cm.overallPlayers, ownerGUID, ownerName)
 				local now = GetTime()
 				player._first = player._first or now
 				player._last = now
 				player.damage = player.damage + amount
 				overall.damage = overall.damage + amount
-				local ps = player.spells[sid]
-				if not ps then
-					ps = { name = sname, amount = 0, hits = 0, crits = 0 }
-					player.spells[sid] = ps
-				end
-				ps.name = sname
-				ps.amount = ps.amount + amount
-				ps.hits = (ps.hits or 0) + 1
-				if crit then ps.crits = (ps.crits or 0) + 1 end
-				local os = overall.spells[sid]
-				if not os then
-					os = { name = sname, amount = 0, hits = 0, crits = 0 }
-					overall.spells[sid] = os
-				end
-				os.name = sname
-				os.amount = os.amount + amount
-				os.hits = (os.hits or 0) + 1
-				if crit then os.crits = (os.crits or 0) + 1 end
-			else
-				addPrePull(ownerGUID, ownerName, amount, 0, sid, sname, crit)
-			end
-			return
-		end
+                                local ps = player.spells[spellId]
+                                if not ps then
+                                        ps = { name = spellName, amount = 0, hits = 0, crits = 0 }
+                                        player.spells[spellId] = ps
+                                end
+                                ps.name = spellName
+                                ps.amount = ps.amount + amount
+                                ps.hits = (ps.hits or 0) + 1
+                                if crit then ps.crits = (ps.crits or 0) + 1 end
+                                local os = overall.spells[spellId]
+                                if not os then
+                                        os = { name = spellName, amount = 0, hits = 0, crits = 0 }
+                                        overall.spells[spellId] = os
+                                end
+                                os.name = spellName
+                                os.amount = os.amount + amount
+                                os.hits = (os.hits or 0) + 1
+                                if crit then os.crits = (os.crits or 0) + 1 end
+                        else
+                                addPrePull(ownerGUID, ownerName, amount, 0, spellId, spellName, crit)
+                        end
+                        return
+                end
 
 		if sub == "DAMAGE_SPLIT" then
 			if not inCombat then return end
@@ -494,39 +494,39 @@ local function handleEvent(self, event, unit)
 			if band(ownerFlags or 0, groupMask) == 0 then return end
 			local amount = (a15 or 0) - (a16 or 0)
 			if amount <= 0 then return end
-			local sid, sname = getSpellInfoFromSub(sub, a12, a15)
-			local crit = a21 or a18
-			if inCombat then
-				local player = acquirePlayer(cm.players, ownerGUID, ownerName)
-				local overall = acquirePlayer(cm.overallPlayers, ownerGUID, ownerName)
+                        local spellId, spellName = getSpellInfoFromSub(sub, a12, a15)
+                        local crit = a21 or a18
+                        if inCombat then
+                                local player = acquirePlayer(cm.players, ownerGUID, ownerName)
+                                local overall = acquirePlayer(cm.overallPlayers, ownerGUID, ownerName)
 				local now = GetTime()
 				player._first = player._first or now
 				player._last = now
 				player.healing = player.healing + amount
 				overall.healing = overall.healing + amount
-				local ps = player.spells[sid]
-				if not ps then
-					ps = { name = sname, amount = 0, hits = 0, crits = 0 }
-					player.spells[sid] = ps
-				end
-				ps.name = sname
-				ps.amount = ps.amount + amount
-				ps.hits = (ps.hits or 0) + 1
-				if crit then ps.crits = (ps.crits or 0) + 1 end
-				local os = overall.spells[sid]
-				if not os then
-					os = { name = sname, amount = 0, hits = 0, crits = 0 }
-					overall.spells[sid] = os
-				end
-				os.name = sname
-				os.amount = os.amount + amount
-				os.hits = (os.hits or 0) + 1
-				if crit then os.crits = (os.crits or 0) + 1 end
-			else
-				addPrePull(ownerGUID, ownerName, 0, amount, sid, sname, crit)
-			end
-			return
-		end
+                                local ps = player.spells[spellId]
+                                if not ps then
+                                        ps = { name = spellName, amount = 0, hits = 0, crits = 0 }
+                                        player.spells[spellId] = ps
+                                end
+                                ps.name = spellName
+                                ps.amount = ps.amount + amount
+                                ps.hits = (ps.hits or 0) + 1
+                                if crit then ps.crits = (ps.crits or 0) + 1 end
+                                local os = overall.spells[spellId]
+                                if not os then
+                                        os = { name = spellName, amount = 0, hits = 0, crits = 0 }
+                                        overall.spells[spellId] = os
+                                end
+                                os.name = spellName
+                                os.amount = os.amount + amount
+                                os.hits = (os.hits or 0) + 1
+                                if crit then os.crits = (os.crits or 0) + 1 end
+                        else
+                                addPrePull(ownerGUID, ownerName, 0, amount, spellId, spellName, crit)
+                        end
+                        return
+                end
 
 		-- We count absorbs exclusively via SPELL_ABSORBED. Some clients also emit *_MISSED with ABSORB for the same event; counting both leads to double credits.
 		if sub == "SPELL_ABSORBED" then
@@ -547,36 +547,36 @@ local function handleEvent(self, event, unit)
 			if not ownerFlags and cm.groupGUIDs and cm.groupGUIDs[ownerGUID] then ownerFlags = COMBATLOG_OBJECT_AFFILIATION_RAID end
 			if band(ownerFlags or 0, groupMask) == 0 then return end
 			if not absorbedAmount or absorbedAmount <= 0 then return end
-			local sid, sname = getSpellInfoFromSub(sub, a12, a15)
-			if inCombat then
-				local p = acquirePlayer(cm.players, ownerGUID, ownerName)
-				local o = acquirePlayer(cm.overallPlayers, ownerGUID, ownerName)
+                        local spellId, spellName = getSpellInfoFromSub(sub, a12, a15)
+                        if inCombat then
+                                local p = acquirePlayer(cm.players, ownerGUID, ownerName)
+                                local o = acquirePlayer(cm.overallPlayers, ownerGUID, ownerName)
 				local now = GetTime()
 				p._first = p._first or now
 				p._last = now
 				p.healing = p.healing + absorbedAmount
 				o.healing = o.healing + absorbedAmount
-				local ps = p.spells[sid]
-				if not ps then
-					ps = { name = sname, amount = 0, hits = 0, crits = 0 }
-					p.spells[sid] = ps
-				end
-				ps.name = sname
-				ps.amount = ps.amount + absorbedAmount
-				ps.hits = (ps.hits or 0) + 1
-				local os = o.spells[sid]
-				if not os then
-					os = { name = sname, amount = 0, hits = 0, crits = 0 }
-					o.spells[sid] = os
-				end
-				os.name = sname
-				os.amount = os.amount + absorbedAmount
-				os.hits = (os.hits or 0) + 1
-			else
-				addPrePull(ownerGUID, ownerName, 0, absorbedAmount, sid, sname, false)
-			end
-			return
-		end
+                                local ps = p.spells[spellId]
+                                if not ps then
+                                        ps = { name = spellName, amount = 0, hits = 0, crits = 0 }
+                                        p.spells[spellId] = ps
+                                end
+                                ps.name = spellName
+                                ps.amount = ps.amount + absorbedAmount
+                                ps.hits = (ps.hits or 0) + 1
+                                local os = o.spells[spellId]
+                                if not os then
+                                        os = { name = spellName, amount = 0, hits = 0, crits = 0 }
+                                        o.spells[spellId] = os
+                                end
+                                os.name = spellName
+                                os.amount = os.amount + absorbedAmount
+                                os.hits = (os.hits or 0) + 1
+                        else
+                                addPrePull(ownerGUID, ownerName, 0, absorbedAmount, spellId, spellName, false)
+                        end
+                        return
+                end
 	end
 end
 


### PR DESCRIPTION
## Summary
- Track spellId and spellName in pre-pull events and merge them into player and overall spell stats
- Populate pre-combat addPrePull calls with spell metadata

## Testing
- `luac -p EnhanceQoLCombatMeter/CombatMeter.lua`


------
https://chatgpt.com/codex/tasks/task_e_689dd66fff788329ba1914f8214f2a33