### PR TITLE
Add spell breakdown tooltips for combat meter bars

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -473,6 +473,45 @@ local function createGroupFrame(groupConfig)
 
 			applyBarTexture(bar)
 
+			-- Tooltip handlers showing top spells for a player
+			bar:SetScript("OnEnter", function(self)
+				local entry = self._entry
+				if not entry then return end
+				local parentFrame = self:GetParent()
+				if not parentFrame then return end
+
+				local pdata
+				if parentFrame.metric == "damageOverall" or parentFrame.metric == "healingOverall" then
+					pdata = addon.CombatMeter.overallPlayers[entry.guid]
+				else
+					pdata = addon.CombatMeter.players[entry.guid]
+				end
+				if not (pdata and pdata.spells) then return end
+
+				local temp = {}
+				local total = 0
+				for _, s in pairs(pdata.spells) do
+					if s.amount and s.amount > 0 then
+						temp[#temp + 1] = s
+						total = total + s.amount
+					end
+				end
+				if total <= 0 or #temp == 0 then return end
+
+				tsort(temp, function(a, b) return a.amount > b.amount end)
+
+				GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+				GameTooltip:AddLine(entry.name or "")
+				local limit = IsShiftKeyDown() and 50 or 10
+				for i = 1, math.min(limit, #temp) do
+					local spell = temp[i]
+					local pct = (spell.amount / total) * 100
+					GameTooltip:AddDoubleLine(spell.name or "", string.format("%s (%.1f%%)", abbreviateNumber(spell.amount), pct))
+				end
+				GameTooltip:Show()
+			end)
+			bar:SetScript("OnLeave", function() GameTooltip:Hide() end)
+
 			frame.bars[index] = bar
 		end
 		return bar
@@ -642,6 +681,7 @@ local function createGroupFrame(groupConfig)
 			totalValue = totalValue + (p.value or 0)
 			local bar = getBar(i)
 			bar:Show()
+			bar._entry = p
 			if bar._max ~= maxValue then
 				bar:SetMinMaxValues(0, maxValue)
 				bar._max = maxValue
@@ -714,7 +754,9 @@ local function createGroupFrame(groupConfig)
 		end
 
 		for i = displayCount + 1, #self.bars do
-			self.bars[i]:Hide()
+			local bar = self.bars[i]
+			bar:Hide()
+			bar._entry = nil
 		end
 
 		local newHeight = 16 + displayCount * barHeight


### PR DESCRIPTION
## Summary
- show spell breakdown tooltip for combat meter bars with shift-expansion
- link bars to their player entry for tooltip lookups

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeterUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_689dd90a03fc8329ad5d16cf4f4fa50f