### PR TITLE
fix: handle nil item level in inventory filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Resolved issues in **DataPanel**.
 - Improved **Combat Meter** DPS/HPS determination accuracy.
+- Fixed an error when filtering inventory by item level.
 
 ---
 

--- a/EnhanceQoL/General/functions.lua
+++ b/EnhanceQoL/General/functions.lua
@@ -378,13 +378,13 @@ local function updateButtonInfo(itemButton, bag, slot, frameName)
 				if addon.itemBagFilters["rarity"] then
 					if nil == addon.itemBagFiltersQuality[itemQuality] or addon.itemBagFiltersQuality[itemQuality] == false then setVisibility = true end
 				end
-				local cilvl = C_Item.GetDetailedItemLevelInfo(itemLink)
-				if addon.itemBagFilters["minLevel"] and (cilvl < addon.itemBagFilters["minLevel"] or (nil == itemEquipLoc or addon.variables.ignoredEquipmentTypes[itemEquipLoc])) then
-					setVisibility = true
-				end
-				if addon.itemBagFilters["maxLevel"] and (cilvl > addon.itemBagFilters["maxLevel"] or (nil == itemEquipLoc or addon.variables.ignoredEquipmentTypes[itemEquipLoc])) then
-					setVisibility = true
-				end
+                                local cilvl = C_Item.GetDetailedItemLevelInfo(itemLink)
+                                if addon.itemBagFilters["minLevel"] and (not cilvl or cilvl < addon.itemBagFilters["minLevel"] or (nil == itemEquipLoc or addon.variables.ignoredEquipmentTypes[itemEquipLoc])) then
+                                        setVisibility = true
+                                end
+                                if addon.itemBagFilters["maxLevel"] and (not cilvl or cilvl > addon.itemBagFilters["maxLevel"] or (nil == itemEquipLoc or addon.variables.ignoredEquipmentTypes[itemEquipLoc])) then
+                                        setVisibility = true
+                                end
 				if addon.itemBagFilters["currentExpension"] and LE_EXPANSION_LEVEL_CURRENT ~= expId then setVisibility = true end
 				if addon.itemBagFilters["equipment"] and (nil == itemEquipLoc or addon.variables.ignoredEquipmentTypes[itemEquipLoc]) then setVisibility = true end
 				if addon.itemBagFilters["bind"] then


### PR DESCRIPTION
## Summary
- handle nil item level when filtering bag items by min/max level
- document inventory item level filter fix in changelog

## Testing
- `luac -p EnhanceQoL/General/functions.lua`

------
https://chatgpt.com/codex/tasks/task_e_689e06c2da508329a43f7301ead6e6ab