### PR TITLE
Group spells with same name in CombatMeter breakdown

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -494,9 +494,21 @@ local function createGroupFrame(groupConfig)
 
 				local temp = {}
 				local total = 0
+				local aggregated = {}
 				for _, s in pairs(spells) do
 					if s.amount and s.amount > 0 then
-						temp[#temp + 1] = s
+						local key = s.name or ""
+						local agg = aggregated[key]
+						if not agg then
+							agg = { name = s.name, icon = s.icon, amount = 0, hits = 0, periodicHits = 0, crits = 0 }
+							aggregated[key] = agg
+							temp[#temp + 1] = agg
+						end
+						agg.amount = agg.amount + (s.amount or 0)
+						agg.hits = (agg.hits or 0) + (s.hits or 0)
+						agg.periodicHits = (agg.periodicHits or 0) + (s.periodicHits or 0)
+						agg.crits = (agg.crits or 0) + (s.crits or 0)
+						agg.icon = agg.icon or s.icon
 						total = total + s.amount
 					end
 				end


### PR DESCRIPTION
## Summary
- Aggregate spells sharing an identical name in CombatMeter's spell breakdown to avoid duplicate entries

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeterUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_689e0f1a14cc83298f671ee0d3d6b4aa