### PR TITLE
Play off-healing sound without LibSharedMedia

### DIFF
--- a/EnhanceQoLMythicPlus/CooldownTracker.lua
+++ b/EnhanceQoLMythicPlus/CooldownTracker.lua
@@ -110,7 +110,7 @@ local function createCooldownBar(spellID, anchorFrame, playerName, unit)
 	if potInfo.text then textLeft = textLeft .. " - " .. potInfo.text end
 
 	if potInfo.isOffhealing and addon.db["potionTrackerOffhealing"] == false then return end
-	if potInfo.isOffhealing then C_VoiceChat.SpeakText(1, "Offhaeling Active", Enum.VoiceTtsDestination.LocalPlayback, 01, 100) end
+	if potInfo.isOffhealing then PlaySoundFile("Interface\\AddOns\\EnhanceQoLSharedMedia\\Sounds\\Voiceovers\\offhealing active.ogg", "Master") end
 
 	local frame = CreateFrame("StatusBar", nil, UIParent, "BackdropTemplate")
 	frame:SetSize(anchorFrame:GetWidth() - addon.db["CooldownTrackerBarHeight"], addon.db["CooldownTrackerBarHeight"]) -- Größe des Balkens


### PR DESCRIPTION
## Summary
- remove LibSharedMedia dependency from cooldown tracker
- play "offhealing active" sound directly from shared media folder when off-healing cooldowns trigger

## Testing
- `stylua EnhanceQoLMythicPlus/CooldownTracker.lua`
- `luacheck EnhanceQoLMythicPlus/CooldownTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689f2a4700408329aac7b21021791bcb