### PR TITLE
Clear CombatMeter tooltip cache

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -172,12 +172,13 @@ local function resetMeter()
 	cm.prePullHead = 1
 	cm.prePullTail = 0
 	wipe(cm.prePullBuffer)
-	
+
 	cm.historySelection = nil
 	cm.historyUnits = nil
 
 	cm.inCombat = UnitAffectingCombat("player")
 	cm.fightStartTime = cm.inCombat and GetTime() or 0
+	wipe(tooltipLookup)
 end
 cm.resetMeter = resetMeter
 
@@ -248,6 +249,7 @@ local function fullRebuildPetOwners()
 	for guid in pairs(unitAffiliation) do
 		if not activeGUIDs[guid] then unitAffiliation[guid] = nil end
 	end
+	wipe(tooltipLookup)
 end
 
 local function updatePetOwner(unit)


### PR DESCRIPTION
## Summary
- wipe tooltipLookup on meter reset
- clear tooltipLookup during pet owner rebuilds

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luacheck EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a02958589c8329b6f12a139377e68f