### PR TITLE
Adjust filter scheduling delay

### DIFF
--- a/EnhanceQoLMythicPlus/DungeonFilter.lua
+++ b/EnhanceQoLMythicPlus/DungeonFilter.lua
@@ -385,7 +385,8 @@ local function ScheduleFilters(initial)
 	if initial then _lastInitial = true end
 	if _filterScheduled then return end
 	_filterScheduled = true
-	C_Timer.After(0, function()
+	local delay = (IsInGroup() and 0.2 or 0.05)
+	C_Timer.After(delay, function()
 		_filterScheduled = false
 		ApplyEQOLFilters(_lastInitial)
 		_lastInitial = false


### PR DESCRIPTION
## Summary
- adjust filter scheduling to use a small delay (0.2s in group, 0.05s solo) before applying filters

## Testing
- `stylua EnhanceQoLMythicPlus/DungeonFilter.lua`
- `luacheck EnhanceQoLMythicPlus/DungeonFilter.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a30fe728bc832994b96ed5afe8e52e