### PR TITLE
Optimize group type handling in buff tracker

### DIFF
--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -56,14 +56,20 @@ local function unregisterEnchantBuff(catId, slot)
 	end
 end
 
+local hasGroupTypeFilters = false
+
 for catId, cat in pairs(addon.db["buffTrackerCategories"]) do
+	if not cat.allowedGroupTypes then cat.allowedGroupTypes = {} end
+	if next(cat.allowedGroupTypes) then hasGroupTypeFilters = true end
 	for id, buff in pairs(cat.buffs or {}) do
 		if not buff.trackType then buff.trackType = "BUFF" end
 		if not buff.allowedSpecs then buff.allowedSpecs = {} end
 		if not buff.allowedClasses then buff.allowedClasses = {} end
 		if not buff.allowedRoles then buff.allowedRoles = {} end
+		if not buff.allowedGroupTypes then buff.allowedGroupTypes = {} end
 		if buff.showCooldown == nil then buff.showCooldown = false end
 		if not buff.conditions then buff.conditions = { join = "AND", conditions = {} } end
+		if next(buff.allowedGroupTypes) then hasGroupTypeFilters = true end
 		if buff.trackType == "ITEM" and buff.slot then
 			registerItemBuff(catId, id, buff.slot)
 		elseif buff.trackType == "ENCHANT" and buff.slot then
@@ -324,11 +330,19 @@ for key, info in pairs(instanceDifficultyGroups) do
 end
 
 local currentInstanceGroup
+local currentGroupType
 
 local function updateInstanceGroup()
 	local _, _, diffID = GetInstanceInfo()
 	if nil == diffID then diffID = "" end
 	currentInstanceGroup = difficultyToGroup[diffID]
+end
+
+local function updateGroupType()
+	local new = IsInRaid() and "RAID" or (IsInGroup() and "PARTY" or "SOLO")
+	local changed = new ~= currentGroupType
+	currentGroupType = new
+	return changed
 end
 
 local DebuffBorderColors = {
@@ -340,6 +354,9 @@ local DebuffBorderColors = {
 }
 
 function categoryAllowed(cat)
+	if cat.allowedGroupTypes and next(cat.allowedGroupTypes) then
+		if not currentGroupType or not cat.allowedGroupTypes[currentGroupType] then return false end
+	end
 	if cat.allowedClasses and next(cat.allowedClasses) then
 		if not cat.allowedClasses[addon.variables.unitClass] then return false end
 	end
@@ -358,6 +375,9 @@ function categoryAllowed(cat)
 end
 
 local function buffAllowed(buff)
+	if buff.allowedGroupTypes and next(buff.allowedGroupTypes) then
+		if not currentGroupType or not buff.allowedGroupTypes[currentGroupType] then return false end
+	end
 	if buff.allowedClasses and next(buff.allowedClasses) then
 		if not buff.allowedClasses[addon.variables.unitClass] then return false end
 	end
@@ -528,9 +548,15 @@ local function rebuildAltMapping()
 	wipe(altToBase)
 	wipe(spellToCat)
 	wipe(chargeSpells)
+	hasGroupTypeFilters = false
 	for catId, cat in pairs(addon.db["buffTrackerCategories"]) do
+		if cat.allowedGroupTypes and next(cat.allowedGroupTypes) then hasGroupTypeFilters = true end
 		for baseId, buff in pairs(cat.buffs or {}) do
-			if not buff.allowedInstances or not next(buff.allowedInstances) or (currentInstanceGroup and buff.allowedInstances[currentInstanceGroup]) then
+			if buff.allowedGroupTypes and next(buff.allowedGroupTypes) then hasGroupTypeFilters = true end
+			if
+				(not buff.allowedInstances or not next(buff.allowedInstances) or (currentInstanceGroup and buff.allowedInstances[currentInstanceGroup]))
+				and (not buff.allowedGroupTypes or not next(buff.allowedGroupTypes) or (currentGroupType and buff.allowedGroupTypes[currentGroupType]))
+			then
 				spellToCat[baseId] = spellToCat[baseId] or {}
 				spellToCat[baseId][catId] = true
 
@@ -1245,7 +1271,13 @@ local function scanBuffs()
 			for _, id in ipairs(getBuffOrder(catId)) do
 				local buff = cat.buffs[id]
 				if not addon.db["buffTrackerHidden"][id] then
-					if not buff or not buff.allowedInstances or not next(buff.allowedInstances) or (currentInstanceGroup and buff.allowedInstances[currentInstanceGroup]) then
+					if
+						not buff
+						or (
+							(not buff.allowedInstances or not next(buff.allowedInstances) or (currentInstanceGroup and buff.allowedInstances[currentInstanceGroup]))
+							and (not buff.allowedGroupTypes or not next(buff.allowedGroupTypes) or (currentGroupType and buff.allowedGroupTypes[currentGroupType]))
+						)
+					then
 						updateBuff(catId, id, nil, firstScan)
 					elseif activeBuffFrames[catId] and activeBuffFrames[catId][id] then
 						activeBuffFrames[catId][id]:Hide()
@@ -1269,32 +1301,22 @@ local function scanBuffs()
 	firstScan = false
 end
 
-local function collectActiveAuras()
-	for _, filter in ipairs({ "HELPFUL", "HARMFUL" }) do
-		local i = 1
-		local aura = C_UnitAuras.GetAuraDataByIndex("player", i, filter)
-		while aura do
-			local base = altToBase[aura.spellId] or aura.spellId
-			auraInstanceMap[aura.auraInstanceID] = { buffId = base }
-			for catId in pairs(spellToCat[base] or {}) do
-				local key = catId .. ":" .. base
-				buffInstances[key] = aura.auraInstanceID
-			end
-			i = i + 1
-			aura = C_UnitAuras.GetAuraDataByIndex("player", i, filter)
-		end
-	end
-end
-
 addon.Aura.buffAnchors = anchors
 addon.Aura.scanBuffs = scanBuffs
 
 local eventFrame = CreateFrame("Frame")
 eventFrame:SetScript("OnEvent", function(_, event, unit, ...)
+	if event == "GROUP_ROSTER_UPDATE" then
+		if hasGroupTypeFilters and updateGroupType() then
+			rebuildAltMapping()
+			scanBuffs()
+		end
+		return
+	end
 	if event == "CHALLENGE_MODE_START" then
-		currentInstanceGroup = difficultyToGroup[8]
+		updateInstanceGroup()
+		updateGroupType()
 		rebuildAltMapping()
-		collectActiveAuras()
 		scanBuffs()
 		return
 	end
@@ -1311,8 +1333,8 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, ...)
 			firstScan = true
 			C_Timer.After(0.1, function()
 				updateInstanceGroup()
+				updateGroupType()
 				rebuildAltMapping()
-				collectActiveAuras()
 				scanBuffs()
 			end)
 			return
@@ -1414,6 +1436,7 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, ...)
 end)
 eventFrame:RegisterUnitEvent("UNIT_AURA", "player")
 eventFrame:RegisterEvent("CHALLENGE_MODE_START")
+eventFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
 eventFrame:RegisterEvent("PLAYER_LOGIN")
 eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 eventFrame:RegisterEvent("ACTIVE_PLAYER_SPECIALIZATION_CHANGED")


### PR DESCRIPTION
## Summary
- Track current group type and support optional group-type filters
- Skip remaps on GROUP_ROSTER_UPDATE unless the group type actually changed
- Remove redundant aura collection before full scans
- Ignore group-type–restricted buffs during mapping and scanning for faster updates

## Testing
- `stylua EnhanceQoLAura/BuffTracker.lua`
- `luacheck EnhanceQoLAura/BuffTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a313bbce208329bc8aa12804b221e9