### PR TITLE
refactor: simplify dungeon filter with hooks

### DIFF
--- a/EnhanceQoLMythicPlus/DungeonFilter.lua
+++ b/EnhanceQoLMythicPlus/DungeonFilter.lua
@@ -190,8 +190,14 @@ local function FilterEntry(entry)
 		return
 	end
 	local selectedID = (type(LFGListSearchPanel_GetSelectedResult) == "function" and LFGListSearchPanel_GetSelectedResult(panel)) or panel.selectedResultID or panel.selectedResult
-	if selectedID and resultID == selectedID then return end
-	if appliedLookup[resultID] then return end
+	if selectedID and resultID == selectedID then
+		entry:SetShown(true)
+		return
+	end
+	if appliedLookup[resultID] then
+		entry:SetShown(true)
+		return
+	end
 	local info = C_LFGList.GetSearchResultInfo(resultID)
 	if not info then return end
 	entry:SetShown(EntryPassesFilter(info))


### PR DESCRIPTION
## Summary
- simplify Mythic+ dungeon filter to hook LFG search entry updates instead of rebuilding lists
- calculate group composition and buffs on-demand per entry
- register only essential LFG events and coalesce refresh after result updates
- refresh visible results immediately when filter options change or state events occur
- skip filtering when no options active and trigger initial refresh on enable

## Testing
- `stylua EnhanceQoLMythicPlus/DungeonFilter.lua`
- `luacheck EnhanceQoLMythicPlus/DungeonFilter.lua --no-config` *(warns about undefined WoW APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68a3219aabd48329a63385feeacaac9b