### PR TITLE
feat(ignore): add tooltip note size controls

### DIFF
--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -2931,6 +2931,36 @@ local function addSocialFrame(container)
 		local cb = addon.functions.createCheckboxAce(checkboxData.text, addon.db[checkboxData.var], checkboxData.callback, desc)
 		groupCore:AddChild(cb)
 	end
+	if addon.db["ignoreTooltipNote"] then
+		local sliderMaxChars = addon.functions.createSliderAce(
+			L["IgnoreTooltipMaxChars"] .. ": " .. addon.db["ignoreTooltipMaxChars"],
+			addon.db["ignoreTooltipMaxChars"],
+			20,
+			200,
+			1,
+			function(self, _, val)
+				addon.db["ignoreTooltipMaxChars"] = val
+				self:SetLabel(L["IgnoreTooltipMaxChars"] .. ": " .. val)
+			end
+		)
+		groupCore:AddChild(sliderMaxChars)
+
+		local sliderWords = addon.functions.createSliderAce(
+			L["IgnoreTooltipWordsPerLine"] .. ": " .. addon.db["ignoreTooltipWordsPerLine"],
+			addon.db["ignoreTooltipWordsPerLine"],
+			1,
+			20,
+			1,
+			function(self, _, val)
+				addon.db["ignoreTooltipWordsPerLine"] = val
+				self:SetLabel(L["IgnoreTooltipWordsPerLine"] .. ": " .. val)
+			end
+		)
+		groupCore:AddChild(sliderWords)
+
+		groupCore:AddChild(addon.functions.createSpacerAce())
+	end
+
 
 	local labelHeadline = addon.functions.createLabelAce("|cffffd700" .. L["IgnoreDesc"], nil, nil, 14)
 	labelHeadline:SetFullWidth(true)
@@ -3906,7 +3936,9 @@ local function initSocial()
 	addon.functions.InitDBValue("enableIgnore", false)
 	addon.functions.InitDBValue("ignoreAttachFriendsFrame", true)
 	addon.functions.InitDBValue("ignoreAnchorFriendsFrame", false)
-	addon.functions.InitDBValue("ignoreTooltipNote", false)
+       addon.functions.InitDBValue("ignoreTooltipNote", false)
+       addon.functions.InitDBValue("ignoreTooltipMaxChars", 100)
+       addon.functions.InitDBValue("ignoreTooltipWordsPerLine", 5)
 	addon.functions.InitDBValue("ignoreFramePoint", "CENTER")
 	addon.functions.InitDBValue("ignoreFrameX", 0)
 	addon.functions.InitDBValue("ignoreFrameY", 0)

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -282,7 +282,7 @@ L["IgnoreServer"] = "Realm"
 L["IgnoreListed"] = "Added"
 L["IgnoreExpires"] = "Expires"
 L["IgnoreNote"] = "Ignore note"
-L["IgnoreNoteDesc"] = "Maximum of 200 chars are visible"
+L["IgnoreNoteDesc"] = "Show note in tooltip. Adjust maximum characters and words per line."
 L["IgnoreEntries"] = "Entries: %d"
 L["IgnoreWindowTitle"] = "Enhanced Ignore"
 L["IgnoreExpiresDays"] = "Expires (days)"
@@ -296,6 +296,8 @@ L["IgnoreAttachFriendsDesc"] = "Automatically show or hide the enhanced ignore l
 L["IgnoreAnchorFriends"] = "Anchor to Friends list"
 L["IgnoreAnchorFriendsDesc"] = "Attach the enhanced ignore list to the Friends window."
 L["IgnoreTooltipNote"] = "Show ignore note in tooltip"
+L["IgnoreTooltipMaxChars"] = "Ignore note max characters"
+L["IgnoreTooltipWordsPerLine"] = "Ignore note words per line"
 L["IgnoreDesc"] =
 	'Blocks duel, pet-battle, trade, invite and whisper requests from ignored players. Automatically adds same-realm names to Blizzard’s ignore list when space is available.\nIn the Dungeon Finder ignored players are shown as "!!! <Name> !!!".\n\nOpen the list with /eil.'
 L["blockDuelRequests"] = "Block duel requests"

--- a/EnhanceQoL/Submodules/Ignore/Ignore.lua
+++ b/EnhanceQoL/Submodules/Ignore/Ignore.lua
@@ -1088,8 +1088,8 @@ local function EQOL_FormatNote(note, maxChars, wordsPerLine)
 	-- normalize whitespace and trim
 	local s = note:gsub("%s+", " "):gsub("^%s+", ""):gsub("%s+$", "")
 	if s == "" then return "" end
-	maxChars = maxChars or 200
-	wordsPerLine = wordsPerLine or 8
+       maxChars = maxChars or 100
+       wordsPerLine = wordsPerLine or 5
 
 	-- split into words
 	local words = {}
@@ -1112,19 +1112,13 @@ local function EQOL_FormatNote(note, maxChars, wordsPerLine)
 
 	local joined = table.concat(out, "\n")
 
-	-- hard cap by characters, prefer cutting at whitespace
-	if #joined <= maxChars then return joined end
-	local truncated = joined:sub(1, maxChars)
-	-- try to cut back to last non-space to avoid trailing partials
-	local cut = truncated:match("^(.*%S)") or truncated
-	-- append "..." if there is room and original was longer
-	if #joined > maxChars and (#cut + 3) <= maxChars then
-		cut = cut .. "..."
-	else
-		-- ensure not exceeding maxChars
-		cut = cut:sub(1, maxChars)
-	end
-	return cut
+       -- hard cap by characters, prefer cutting at whitespace
+       if #joined <= maxChars then return joined end
+       if maxChars <= 3 then return joined:sub(1, maxChars) end
+       local truncated = joined:sub(1, maxChars - 3)
+       -- try to cut back to last non-space to avoid trailing partials
+       local cut = truncated:match("^(.*%S)") or truncated
+       return cut .. "..."
 end
 
 if not Ignore.tooltipHookInstalled then


### PR DESCRIPTION
## Summary
- allow configuring ignore tooltip note length and width
- append ellipsis when truncating ignore notes
- add English strings for new ignore options

## Testing
- `luacheck EnhanceQoL/Submodules/Ignore/Ignore.lua EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`

------
https://chatgpt.com/codex/tasks/task_e_68a420888d4c8329a8adc24c7f67601a