### PR TITLE
Add currency tracker datapanel stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### ✨ Added
+
+- DataPanel currency stream: per-currency tooltips, optional description hiding, and red coloring when capped
+
 ## [4.6.0] – 2025-08-18
 
 ### ✨ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - DataPanel currency stream: per-currency tooltips, optional description hiding, and red coloring when capped
 
+### 🐛 Fixed
+
+- DataPanel currency stream: per-currency tooltips now obey the description toggle and no longer show stray "Right-Click for options" tooltips
+
 ## [4.6.0] – 2025-08-18
 
 ### ✨ Added

--- a/EnhanceQoL/Core/DataPanel.lua
+++ b/EnhanceQoL/Core/DataPanel.lua
@@ -198,6 +198,7 @@ function DataPanel.Create(id, name)
 				end
 			end
 			data.tooltip = payload.tooltip
+			data.hover = payload.hover
 			data.OnMouseEnter = payload.OnMouseEnter
 			data.OnMouseLeave = payload.OnMouseLeave
 			if payload.OnClick ~= nil then data.OnClick = payload.OnClick end

--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -9,57 +9,6 @@ local tracked = {}
 local trackedDirty = true
 local measureFont = UIParent:CreateFontString()
 
-local function handleMouseEnter(button)
-	if not db or not db.tooltipPerCurrency then return end
-	local slot = button.slot
-	local function update()
-		local hover = slot.hover
-		if not hover then return end
-		local x, _ = GetCursorPosition()
-		local scale = UIParent:GetEffectiveScale()
-		x = x / scale
-		local left = button:GetLeft()
-		local relx = x - left
-		for _, h in ipairs(hover) do
-			if relx >= h.start and relx <= h.stop then
-				if slot.lastTip ~= h.id then
-					GameTooltip:SetOwner(button, "ANCHOR_TOPLEFT")
-					GameTooltip:SetCurrencyByID(h.id)
-					if db.showDescription == false then
-						local info = C_CurrencyInfo.GetCurrencyInfo(h.id)
-						local desc = info and info.description
-						if desc and desc ~= "" then
-							for i = 2, GameTooltip:NumLines() do
-								local leftText = _G[GameTooltip:GetName() .. "TextLeft" .. i]
-								if leftText and leftText:GetText() == desc then
-									leftText:SetText("")
-									break
-								end
-							end
-						end
-					end
-					GameTooltip:Show()
-					slot.lastTip = h.id
-				end
-				return
-			end
-		end
-		if slot.lastTip then
-			GameTooltip:Hide()
-			slot.lastTip = nil
-		end
-	end
-	button:SetScript("OnUpdate", update)
-	update()
-end
-
-local function handleMouseLeave(button)
-	if not db or not db.tooltipPerCurrency then return end
-	button:SetScript("OnUpdate", nil)
-	if button.slot then button.slot.lastTip = nil end
-	GameTooltip:Hide()
-end
-
 local function rebuildTracked()
 	if not db then return end
 	for k in pairs(tracked) do
@@ -342,8 +291,15 @@ local provider = {
 	OnClick = function(_, btn)
 		if btn == "RightButton" then createAceWindow() end
 	end,
-	OnMouseEnter = handleMouseEnter,
-	OnMouseLeave = handleMouseLeave,
+	OnMouseEnter = function(b)
+		local tip = GameTooltip
+		tip:ClearLines()
+		tip:SetOwner(b, "ANCHOR_TOPLEFT")
+		-- tip:SetCurrencyByID(h.id)
+
+		tip:AddLine(L["Right-Click for options"])
+		tip:Show()
+	end,
 }
 
 stream = EnhanceQoL.DataHub.RegisterStream(provider)

--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -25,17 +25,30 @@ local function handleMouseEnter(button)
 				if slot.lastTip ~= h.id then
 					GameTooltip:SetOwner(button, "ANCHOR_TOPLEFT")
 					GameTooltip:SetCurrencyByID(h.id)
+					if db.showDescription == false then
+						local info = C_CurrencyInfo.GetCurrencyInfo(h.id)
+						local desc = info and info.description
+						if desc and desc ~= "" then
+							for i = 2, GameTooltip:NumLines() do
+								local leftText = _G[GameTooltip:GetName() .. "TextLeft" .. i]
+								if leftText and leftText:GetText() == desc then
+									leftText:SetText("")
+									break
+								end
+							end
+						end
+					end
 					GameTooltip:Show()
 					slot.lastTip = h.id
 				end
 				return
 			end
 		end
-		if slot.lastTip ~= "default" then
+		if slot.lastTip then
 			GameTooltip:SetOwner(button, "ANCHOR_TOPLEFT")
 			GameTooltip:SetText(L["Right-Click for options"])
 			GameTooltip:Show()
-			slot.lastTip = "default"
+			slot.lastTip = nil
 		end
 	end
 	button:SetScript("OnUpdate", update)
@@ -311,7 +324,7 @@ local function checkCurrencies(stream)
 			stream.snapshot.tooltip = L["Right-Click for options"]
 		end
 	else
-		stream.snapshot.tooltip = nil
+		stream.snapshot.tooltip = L["Right-Click for options"]
 	end
 end
 

--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -159,7 +159,12 @@ local function checkCurrencies(stream)
 		end
 	end
 
-	local newText = table.concat(parts, " ")
+	local newText
+	if #parts > 0 then
+		newText = table.concat(parts, " ")
+	else
+		newText = L["Right-Click for options"]
+	end
 	if stream.snapshot.text ~= newText or stream.snapshot.fontSize ~= size then
 		stream.snapshot.text = newText
 		stream.snapshot.fontSize = size

--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -45,9 +45,7 @@ local function handleMouseEnter(button)
 			end
 		end
 		if slot.lastTip then
-			GameTooltip:SetOwner(button, "ANCHOR_TOPLEFT")
-			GameTooltip:SetText(L["Right-Click for options"])
-			GameTooltip:Show()
+			GameTooltip:Hide()
 			slot.lastTip = nil
 		end
 	end
@@ -59,6 +57,7 @@ local function handleMouseLeave(button)
 	if not db or not db.tooltipPerCurrency then return end
 	button:SetScript("OnUpdate", nil)
 	if button.slot then button.slot.lastTip = nil end
+	GameTooltip:Hide()
 end
 
 local function rebuildTracked()
@@ -171,8 +170,8 @@ local function createAceWindow()
 	local frame = AceGUI:Create("Window")
 	aceWindowWidget = frame
 	frame:SetTitle(GAMEMENU_OPTIONS)
-	frame:SetWidth(320)
-	frame:SetHeight(400)
+	frame:SetWidth(280)
+	frame:SetHeight(320)
 	frame:SetLayout("List")
 
 	db._windowStatus = db._windowStatus or {}

--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -304,19 +304,12 @@ local provider = {
 			for _, h in ipairs(hover) do
 				if mx >= h.start and mx <= h.stop then
 					tip:SetCurrencyByID(h.id)
-					tip:AddLine(("ID %d"):format(h.id))
 					tip:AddLine(" ")
 					break
 				end
 			end
-			tip:AddLine(L["Right-Click for options"])
-		elseif stream.snapshot and stream.snapshot.tooltip then
-			for line in string.gmatch(stream.snapshot.tooltip, "[^\n]+") do
-				tip:AddLine(line)
-			end
-		else
-			tip:AddLine(L["Right-Click for options"])
 		end
+		tip:AddLine(L["Right-Click for options"])
 		tip:Show()
 	end,
 }

--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -295,9 +295,28 @@ local provider = {
 		local tip = GameTooltip
 		tip:ClearLines()
 		tip:SetOwner(b, "ANCHOR_TOPLEFT")
-		-- tip:SetCurrencyByID(h.id)
 
-		tip:AddLine(L["Right-Click for options"])
+		local hover = stream.snapshot and stream.snapshot.hover
+		if hover and #hover > 0 then
+			local mx = GetCursorPosition()
+			local scale = b:GetEffectiveScale()
+			mx = mx / scale - b:GetLeft()
+			for _, h in ipairs(hover) do
+				if mx >= h.start and mx <= h.stop then
+					tip:SetCurrencyByID(h.id)
+					tip:AddLine(("ID %d"):format(h.id))
+					tip:AddLine(" ")
+					break
+				end
+			end
+			tip:AddLine(L["Right-Click for options"])
+		elseif stream.snapshot and stream.snapshot.tooltip then
+			for line in string.gmatch(stream.snapshot.tooltip, "[^\n]+") do
+				tip:AddLine(line)
+			end
+		else
+			tip:AddLine(L["Right-Click for options"])
+		end
 		tip:Show()
 	end,
 }

--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -180,8 +180,8 @@ local function checkCurrencies(stream)
 	for _, id in ipairs(db.ids) do
 		local info = C_CurrencyInfo.GetCurrencyInfo(id)
 		if info then
-			if not iconCache[id] and info.icon then iconCache[id] = info.icon end
-			local icon = iconCache[id] or info.icon
+			if not iconCache[id] and info.iconFileID then iconCache[id] = info.iconFileID end
+			local icon = iconCache[id] or info.iconFileID
 			parts[#parts + 1] = ("|T%s:%d:%d:0:0|t %d"):format(icon or 0, size, size, info.quantity or 0)
 		end
 	end

--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -1,0 +1,165 @@
+-- luacheck: globals EnhanceQoL GAMEMENU_OPTIONS C_CurrencyInfo
+local addonName, addon = ...
+local L = addon.L
+
+local AceGUI = addon.AceGUI
+local db
+local stream
+
+local function ensureDB()
+	addon.db.datapanel = addon.db.datapanel or {}
+	addon.db.datapanel.currency = addon.db.datapanel.currency or {}
+	db = addon.db.datapanel.currency
+	db.fontSize = db.fontSize or 14
+	db.ids = db.ids or {}
+end
+
+local function RestorePosition(frame)
+	if db.point and db.x and db.y then
+		frame:ClearAllPoints()
+		frame:SetPoint(db.point, UIParent, db.point, db.x, db.y)
+	end
+end
+
+local aceWindow
+local listContainer
+
+local function renderList()
+	if not listContainer then return end
+	listContainer:ReleaseChildren()
+	for i, id in ipairs(db.ids) do
+		local info = C_CurrencyInfo.GetCurrencyInfo(id)
+		local name = info and info.name or ("ID %d"):format(id)
+		local row = addon.functions.createContainer("SimpleGroup", "Flow")
+
+		local label = AceGUI:Create("Label")
+		label:SetText(("%s (%d)"):format(name, id))
+		label:SetWidth(160)
+		row:AddChild(label)
+
+		local up = AceGUI:Create("Button")
+		up:SetText("↑")
+		up:SetWidth(30)
+		up:SetCallback("OnClick", function()
+			if i > 1 then
+				db.ids[i], db.ids[i - 1] = db.ids[i - 1], db.ids[i]
+				renderList()
+				addon.DataHub:RequestUpdate(stream)
+			end
+		end)
+		row:AddChild(up)
+
+		local down = AceGUI:Create("Button")
+		down:SetText("↓")
+		down:SetWidth(30)
+		down:SetCallback("OnClick", function()
+			if i < #db.ids then
+				db.ids[i], db.ids[i + 1] = db.ids[i + 1], db.ids[i]
+				renderList()
+				addon.DataHub:RequestUpdate(stream)
+			end
+		end)
+		row:AddChild(down)
+
+		local remove = AceGUI:Create("Button")
+		remove:SetText("X")
+		remove:SetWidth(30)
+		remove:SetCallback("OnClick", function()
+			table.remove(db.ids, i)
+			renderList()
+			addon.DataHub:RequestUpdate(stream)
+		end)
+		row:AddChild(remove)
+
+		listContainer:AddChild(row)
+	end
+end
+
+local function createAceWindow()
+	if aceWindow then
+		aceWindow:Show()
+		return
+	end
+	ensureDB()
+	local frame = AceGUI:Create("Window")
+	aceWindow = frame.frame
+	frame:SetTitle(GAMEMENU_OPTIONS)
+	frame:SetWidth(320)
+	frame:SetHeight(400)
+	frame:SetLayout("List")
+
+	frame.frame:SetScript("OnShow", function(self) RestorePosition(self) end)
+	frame.frame:SetScript("OnHide", function(self)
+		local point, _, _, xOfs, yOfs = self:GetPoint()
+		db.point = point
+		db.x = xOfs
+		db.y = yOfs
+	end)
+
+	local fontSize = AceGUI:Create("Slider")
+	fontSize:SetLabel("Font size")
+	fontSize:SetSliderValues(8, 32, 1)
+	fontSize:SetValue(db.fontSize)
+	fontSize:SetCallback("OnValueChanged", function(_, _, val)
+		db.fontSize = val
+		addon.DataHub:RequestUpdate(stream)
+	end)
+	frame:AddChild(fontSize)
+
+	local addGroup = addon.functions.createContainer("SimpleGroup", "Flow")
+	local addBox = AceGUI:Create("EditBox")
+	addBox:SetLabel("Currency ID")
+	addBox:SetWidth(150)
+	addGroup:AddChild(addBox)
+	local addBtn = AceGUI:Create("Button")
+	addBtn:SetText("Add")
+	addBtn:SetWidth(60)
+	addBtn:SetCallback("OnClick", function()
+		local id = tonumber(addBox:GetText())
+		if id then
+			table.insert(db.ids, id)
+			addBox:SetText("")
+			renderList()
+			addon.DataHub:RequestUpdate(stream)
+		end
+	end)
+	addGroup:AddChild(addBtn)
+	frame:AddChild(addGroup)
+
+	listContainer = addon.functions.createContainer("SimpleGroup", "List")
+	frame:AddChild(listContainer)
+	renderList()
+
+	frame.frame:Show()
+end
+
+local function checkCurrencies(stream)
+	ensureDB()
+	local size = db.fontSize or 14
+	local texts = {}
+	for _, id in ipairs(db.ids) do
+		local info = C_CurrencyInfo.GetCurrencyInfo(id)
+		if info and info.icon then texts[#texts + 1] = ("|T%s:%d:%d:0:0|t %d"):format(info.icon, size, size, info.quantity or 0) end
+	end
+	stream.snapshot.fontSize = size
+	stream.snapshot.text = table.concat(texts, " ")
+	if not stream.snapshot.tooltip then stream.snapshot.tooltip = L["Right-Click for options"] end
+end
+
+local provider = {
+	id = "currency",
+	version = 1,
+	title = "Currencies",
+	update = checkCurrencies,
+	events = {
+		PLAYER_LOGIN = function(stream) addon.DataHub:RequestUpdate(stream) end,
+		CURRENCY_DISPLAY_UPDATE = function(stream) addon.DataHub:RequestUpdate(stream) end,
+	},
+	OnClick = function(_, btn)
+		if btn == "RightButton" then createAceWindow() end
+	end,
+}
+
+stream = EnhanceQoL.DataHub.RegisterStream(provider)
+
+return provider

--- a/EnhanceQoL/Core/Streams/Streams.xml
+++ b/EnhanceQoL/Core/Streams/Streams.xml
@@ -1,10 +1,9 @@
-<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
-..\FrameXML\UI.xsd">
-	<Script file="Stream_Difficulty.lua"/>
-	<Script file="Stream_Durability.lua"/>
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\\FrameXML\\UI.xsd">
+        <Script file="Stream_Currency.lua"/>
+        <Script file="Stream_Difficulty.lua"/>
+        <Script file="Stream_Durability.lua"/>
         <Script file="Stream_Friends.lua"/>
         <Script file="Stream_Gold.lua"/>
-        <Script file="Stream_Currency.lua"/>
         <Script file="Stream_Stats.lua"/>
         <Script file="Stream_Talentbuilt.lua"/>
 </Ui>

--- a/EnhanceQoL/Core/Streams/Streams.xml
+++ b/EnhanceQoL/Core/Streams/Streams.xml
@@ -2,8 +2,9 @@
 ..\FrameXML\UI.xsd">
 	<Script file="Stream_Difficulty.lua"/>
 	<Script file="Stream_Durability.lua"/>
-	<Script file="Stream_Friends.lua"/>
-	<Script file="Stream_Gold.lua"/>
-	<Script file="Stream_Stats.lua"/>
-	<Script file="Stream_Talentbuilt.lua"/>
+        <Script file="Stream_Friends.lua"/>
+        <Script file="Stream_Gold.lua"/>
+        <Script file="Stream_Currency.lua"/>
+        <Script file="Stream_Stats.lua"/>
+        <Script file="Stream_Talentbuilt.lua"/>
 </Ui>

--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -4703,7 +4703,7 @@ local function initCharacter()
 
 	local function updateCloakUpgradeButton()
 		if PaperDollFrame and PaperDollFrame:IsShown() then
-			if addon.db["showCloakUpgradeButton"] and IsEquippedItem(235499) then
+			if addon.db["showCloakUpgradeButton"] and C_Item.IsEquippedItem(235499) then
 				addon.general.cloakUpgradeFrame:Show()
 			else
 				addon.general.cloakUpgradeFrame:Hide()

--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -10,7 +10,7 @@ end
 local L = LibStub("AceLocale-3.0"):GetLocale("EnhanceQoL_Aura")
 local AceGUI = addon.AceGUI
 
--- luacheck: globals ChatFrame_OpenChat
+-- luacheck: globals ChatFrame_OpenChat ActionButtonSpellAlertManager
 
 local bleedList = {
 	-- Cinderbrew Meatery
@@ -109,9 +109,9 @@ local function setGlow(frame, enabled)
 	if frame._glow == enabled then return end
 	frame._glow = enabled
 	if enabled then
-		ActionButton_ShowOverlayGlow(frame)
+		ActionButtonSpellAlertManager:ShowAlert(frame)
 	else
-		ActionButton_HideOverlayGlow(frame)
+		ActionButtonSpellAlertManager:HideAlert(frame)
 	end
 end
 

--- a/EnhanceQoLAura/CooldownNotify.lua
+++ b/EnhanceQoLAura/CooldownNotify.lua
@@ -30,6 +30,7 @@ local applyAnchor
 local ShareCategory
 local importCategory
 local exportCategory
+local GetItemInfo = C_Item.GetItemInfo
 
 for _, cat in pairs(addon.db.cooldownNotifyCategories or {}) do
 	if cat.useAdvancedTracking == nil then cat.useAdvancedTracking = true end

--- a/EnhanceQoLTooltip/EnhanceQoLTooltip.lua
+++ b/EnhanceQoLTooltip/EnhanceQoLTooltip.lua
@@ -33,8 +33,10 @@ local function checkCurrency(tooltip, id)
 	if tooltip:IsForbidden() or tooltip:IsProtected() then return end
 	if not id then return end
 
-	if addon.db["TooltipShowCurrencyID"] then tooltip:AddLine(" ")
-	tooltip:AddDoubleLine(L["NPCID"], id) end
+	if addon.db["TooltipShowCurrencyID"] then
+		tooltip:AddLine(" ")
+		tooltip:AddDoubleLine(L["CurrencyID"], id)
+	end
 
 	if not addon.db["TooltipShowCurrencyAccountWide"] then return end
 	local charList = C_CurrencyInfo.FetchCurrencyDataFromAccountCharacters(id)
@@ -630,6 +632,7 @@ local function addCurrencyFrame(container)
 
 	local data = {
 		{ text = L["TooltipShowCurrencyAccountWide"], var = "TooltipShowCurrencyAccountWide" },
+		{ text = L["TooltipShowCurrencyID"], var = "TooltipShowCurrencyID" },
 	}
 
 	table.sort(data, function(a, b) return a.text < b.text end)

--- a/EnhanceQoLTooltip/EnhanceQoLTooltip.lua
+++ b/EnhanceQoLTooltip/EnhanceQoLTooltip.lua
@@ -32,6 +32,10 @@ end
 local function checkCurrency(tooltip, id)
 	if tooltip:IsForbidden() or tooltip:IsProtected() then return end
 	if not id then return end
+
+	if addon.db["TooltipShowCurrencyID"] then tooltip:AddLine(" ")
+	tooltip:AddDoubleLine(L["NPCID"], id) end
+
 	if not addon.db["TooltipShowCurrencyAccountWide"] then return end
 	local charList = C_CurrencyInfo.FetchCurrencyDataFromAccountCharacters(id)
 

--- a/EnhanceQoLTooltip/Init.lua
+++ b/EnhanceQoLTooltip/Init.lua
@@ -39,6 +39,10 @@ addon.functions.InitDBValue("TooltipDebuffHideType", 1)
 addon.functions.InitDBValue("TooltipDebuffHideInCombat", false)
 addon.functions.InitDBValue("TooltipDebuffHideInDungeon", false)
 
+-- Currency
+addon.functions.InitDBValue("TooltipShowCurrencyAccountWide", false)
+addon.functions.InitDBValue("TooltipShowCurrencyID", false)
+
 addon.Tooltip = {}
 addon.LTooltip = {} -- Locales for MythicPlus
 addon.Tooltip.functions = {}

--- a/EnhanceQoLTooltip/Locales/enUS.lua
+++ b/EnhanceQoLTooltip/Locales/enUS.lua
@@ -76,3 +76,5 @@ L["TooltipShowQuestID"] = "Show Quest ID"
 
 -- Currency
 L["TooltipShowCurrencyAccountWide"] = "Show account-wide currency on tooltip"
+L["TooltipShowCurrencyID"] = "Show currency ID on Tooltip"
+L["CurrencyID"] = "CurrencyID"

--- a/EnhanceQoLVendor/CraftShopper.lua
+++ b/EnhanceQoLVendor/CraftShopper.lua
@@ -390,7 +390,7 @@ local function CreateCraftShopperFrame()
 					row:SetLayout("Flow")
 
 					local label = AceGUI:Create("InteractiveLabel")
-					local color = select(4, GetItemQualityColor(quality or 1))
+					local color = select(4, C_Item.GetItemQualityColor(quality or 1))
 					label:SetText(("|c%s%s|r"):format(color, name))
 					label:SetFont(normalFont, 14, normalFlags)
 					label:SetCallback("OnEnter", function(widget)


### PR DESCRIPTION
## Summary
- add a currency tracker stream for the datapanel
- allow configuring currency IDs, ordering and font size

## Testing
- `stylua EnhanceQoL/Core/Streams/Stream_Currency.lua`
- `luacheck EnhanceQoL/Core/Streams/Stream_Currency.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a45a496a788329b14f3b8aaec01e8c