### PR TITLE
Add Stream Currency fallback and include in Streams

### DIFF
--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -159,7 +159,12 @@ local function checkCurrencies(stream)
 		end
 	end
 
-	local newText = table.concat(parts, " ")
+	local newText
+	if #parts > 0 then
+		newText = table.concat(parts, " ")
+	else
+		newText = L["Right-Click for options"]
+	end
 	if stream.snapshot.text ~= newText or stream.snapshot.fontSize ~= size then
 		stream.snapshot.text = newText
 		stream.snapshot.fontSize = size

--- a/EnhanceQoL/Core/Streams/Streams.xml
+++ b/EnhanceQoL/Core/Streams/Streams.xml
@@ -1,10 +1,9 @@
-<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
-..\FrameXML\UI.xsd">
-	<Script file="Stream_Difficulty.lua"/>
-	<Script file="Stream_Durability.lua"/>
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\\FrameXML\\UI.xsd">
+        <Script file="Stream_Currency.lua"/>
+        <Script file="Stream_Difficulty.lua"/>
+        <Script file="Stream_Durability.lua"/>
         <Script file="Stream_Friends.lua"/>
         <Script file="Stream_Gold.lua"/>
-        <Script file="Stream_Currency.lua"/>
         <Script file="Stream_Stats.lua"/>
         <Script file="Stream_Talentbuilt.lua"/>
 </Ui>


### PR DESCRIPTION
## Summary
- ensure Stream Currency script is included in stream registry
- show placeholder text when no currencies configured

## Testing
- `stylua EnhanceQoL/Core/Streams/Stream_Currency.lua`
- `luacheck EnhanceQoL/Core/Streams/Stream_Currency.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a472be6f6883298a7844bc658321d0