### PR TITLE
feat(currency): icon controls and event-filtered updates

### DIFF
--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -43,32 +43,43 @@ local function renderList()
 		label:SetWidth(160)
 		row:AddChild(label)
 
-		local up = AceGUI:Create("Button")
-		up:SetText("↑")
-		up:SetWidth(30)
-		up:SetCallback("OnClick", function()
-			if idx > 1 then
+		if idx > 1 then
+			local up = AceGUI:Create("Icon")
+			up:SetImage("Interface\\Buttons\\UI-ScrollBar-ScrollUpButton-Up") -- TODO replace placeholder
+			up:SetImageSize(16, 16)
+			up:SetWidth(30)
+			up:SetCallback("OnClick", function()
 				db.ids[idx], db.ids[idx - 1] = db.ids[idx - 1], db.ids[idx]
 				renderList()
 				RequestUpdateDebounced()
-			end
-		end)
-		row:AddChild(up)
+			end)
+			row:AddChild(up)
+		else
+			local spacer = AceGUI:Create("Label")
+			spacer:SetWidth(30)
+			row:AddChild(spacer)
+		end
 
-		local down = AceGUI:Create("Button")
-		down:SetText("↓")
-		down:SetWidth(30)
-		down:SetCallback("OnClick", function()
-			if idx < #db.ids then
+		if idx < #db.ids then
+			local down = AceGUI:Create("Icon")
+			down:SetImage("Interface\\Buttons\\UI-ScrollBar-ScrollDownButton-Up") -- TODO replace placeholder
+			down:SetImageSize(16, 16)
+			down:SetWidth(30)
+			down:SetCallback("OnClick", function()
 				db.ids[idx], db.ids[idx + 1] = db.ids[idx + 1], db.ids[idx]
 				renderList()
 				RequestUpdateDebounced()
-			end
-		end)
-		row:AddChild(down)
+			end)
+			row:AddChild(down)
+		else
+			local spacer = AceGUI:Create("Label")
+			spacer:SetWidth(30)
+			row:AddChild(spacer)
+		end
 
-		local remove = AceGUI:Create("Button")
-		remove:SetText("X")
+		local remove = AceGUI:Create("Icon")
+		remove:SetImage("Interface\\Buttons\\UI-GroupLoot-Pass-Up") -- TODO replace placeholder
+		remove:SetImageSize(16, 16)
 		remove:SetWidth(30)
 		remove:SetCallback("OnClick", function()
 			table.remove(db.ids, idx)
@@ -179,7 +190,15 @@ local provider = {
 	update = checkCurrencies,
 	events = {
 		PLAYER_LOGIN = function() RequestUpdateDebounced() end,
-		CURRENCY_DISPLAY_UPDATE = function() RequestUpdateDebounced() end,
+		CURRENCY_DISPLAY_UPDATE = function(_, currencyType)
+			ensureDB()
+			for _, tracked in ipairs(db.ids) do
+				if tracked == currencyType then
+					RequestUpdateDebounced()
+					break
+				end
+			end
+		end,
 	},
 	OnClick = function(_, btn)
 		if btn == "RightButton" then createAceWindow() end


### PR DESCRIPTION
## Summary
- use icon widgets for currency list controls with placeholder textures
- suppress up/down buttons at list edges
- update currency stream only when tracked currency changes via `CURRENCY_DISPLAY_UPDATE`

## Testing
- `stylua EnhanceQoL/Core/Streams/Stream_Currency.lua`
- `luacheck EnhanceQoL/Core/Streams/Stream_Currency.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a47aa944e08329a73f333406ee2eb4