### PR TITLE
feat(tooltip): add currency ID display option

### DIFF
--- a/EnhanceQoLTooltip/EnhanceQoLTooltip.lua
+++ b/EnhanceQoLTooltip/EnhanceQoLTooltip.lua
@@ -33,8 +33,10 @@ local function checkCurrency(tooltip, id)
 	if tooltip:IsForbidden() or tooltip:IsProtected() then return end
 	if not id then return end
 
-	if addon.db["TooltipShowCurrencyID"] then tooltip:AddLine(" ")
-	tooltip:AddDoubleLine(L["NPCID"], id) end
+	if addon.db["TooltipShowCurrencyID"] then
+		tooltip:AddLine(" ")
+		tooltip:AddDoubleLine(L["CurrencyID"], id)
+	end
 
 	if not addon.db["TooltipShowCurrencyAccountWide"] then return end
 	local charList = C_CurrencyInfo.FetchCurrencyDataFromAccountCharacters(id)
@@ -630,6 +632,7 @@ local function addCurrencyFrame(container)
 
 	local data = {
 		{ text = L["TooltipShowCurrencyAccountWide"], var = "TooltipShowCurrencyAccountWide" },
+		{ text = L["TooltipShowCurrencyID"], var = "TooltipShowCurrencyID" },
 	}
 
 	table.sort(data, function(a, b) return a.text < b.text end)

--- a/EnhanceQoLTooltip/Init.lua
+++ b/EnhanceQoLTooltip/Init.lua
@@ -39,6 +39,10 @@ addon.functions.InitDBValue("TooltipDebuffHideType", 1)
 addon.functions.InitDBValue("TooltipDebuffHideInCombat", false)
 addon.functions.InitDBValue("TooltipDebuffHideInDungeon", false)
 
+-- Currency
+addon.functions.InitDBValue("TooltipShowCurrencyAccountWide", false)
+addon.functions.InitDBValue("TooltipShowCurrencyID", false)
+
 addon.Tooltip = {}
 addon.LTooltip = {} -- Locales for MythicPlus
 addon.Tooltip.functions = {}

--- a/EnhanceQoLTooltip/Locales/enUS.lua
+++ b/EnhanceQoLTooltip/Locales/enUS.lua
@@ -76,3 +76,5 @@ L["TooltipShowQuestID"] = "Show Quest ID"
 
 -- Currency
 L["TooltipShowCurrencyAccountWide"] = "Show account-wide currency on tooltip"
+L["TooltipShowCurrencyID"] = "Show currency ID on Tooltip"
+L["CurrencyID"] = "CurrencyID"


### PR DESCRIPTION
## Summary
- let tooltip show currency IDs
- make currency options user-configurable

## Testing
- `stylua EnhanceQoLTooltip/EnhanceQoLTooltip.lua EnhanceQoLTooltip/Init.lua EnhanceQoLTooltip/Locales/enUS.lua`
- `luac -p EnhanceQoLTooltip/EnhanceQoLTooltip.lua EnhanceQoLTooltip/Init.lua EnhanceQoLTooltip/Locales/enUS.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a47f8c8cc4832989bb5d29937cd877