### PR TITLE
Replace deprecated overlay glow functions

### DIFF
--- a/EnhanceQoLAura/BuffTracker.lua
+++ b/EnhanceQoLAura/BuffTracker.lua
@@ -10,7 +10,7 @@ end
 local L = LibStub("AceLocale-3.0"):GetLocale("EnhanceQoL_Aura")
 local AceGUI = addon.AceGUI
 
--- luacheck: globals ChatFrame_OpenChat
+-- luacheck: globals ChatFrame_OpenChat ActionButtonSpellAlertManager
 
 local bleedList = {
 	-- Cinderbrew Meatery
@@ -109,9 +109,9 @@ local function setGlow(frame, enabled)
 	if frame._glow == enabled then return end
 	frame._glow = enabled
 	if enabled then
-		ActionButton_ShowOverlayGlow(frame)
+		ActionButtonSpellAlertManager:ShowAlert(frame)
 	else
-		ActionButton_HideOverlayGlow(frame)
+		ActionButtonSpellAlertManager:HideAlert(frame)
 	end
 end
 


### PR DESCRIPTION
## Summary
- swap deprecated `ActionButton_ShowOverlayGlow` and `ActionButton_HideOverlayGlow` calls with `ActionButtonSpellAlertManager` methods
- declare `ActionButtonSpellAlertManager` as a known global for luacheck

## Testing
- `stylua EnhanceQoLAura/BuffTracker.lua`
- `luacheck EnhanceQoLAura/BuffTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a4a2162b188329bd2a9e7b1ccb6da4