### PR TITLE
feat: enhance currency datapanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### ✨ Added
+
+- DataPanel currency stream: per-currency tooltips, optional description hiding, and red coloring when capped
+
 ## [4.6.0] – 2025-08-18
 
 ### ✨ Added

--- a/EnhanceQoL/Core/DataPanel.lua
+++ b/EnhanceQoL/Core/DataPanel.lua
@@ -198,6 +198,7 @@ function DataPanel.Create(id, name)
 				end
 			end
 			data.tooltip = payload.tooltip
+			data.hover = payload.hover
 			data.OnMouseEnter = payload.OnMouseEnter
 			data.OnMouseLeave = payload.OnMouseLeave
 			if payload.OnClick ~= nil then data.OnClick = payload.OnClick end


### PR DESCRIPTION
## Summary
- add per-currency tooltip handling for the currency data panel
- color values red when capped and allow hiding tooltip descriptions
- support custom tooltip style and persist hover data

## Testing
- `stylua EnhanceQoL/Core/DataPanel.lua EnhanceQoL/Core/Streams/Stream_Currency.lua`
- `luacheck EnhanceQoL/Core/DataPanel.lua EnhanceQoL/Core/Streams/Stream_Currency.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a4a86f36688329814c6c240871cc8e