### PR TITLE
fix: respect currency tooltip settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - DataPanel currency stream: per-currency tooltips, optional description hiding, and red coloring when capped
 
+### 🐛 Fixed
+
+- DataPanel currency stream: per-currency tooltips now obey the description toggle and no longer show stray "Right-Click for options" tooltips
+
 ## [4.6.0] – 2025-08-18
 
 ### ✨ Added

--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -25,17 +25,30 @@ local function handleMouseEnter(button)
 				if slot.lastTip ~= h.id then
 					GameTooltip:SetOwner(button, "ANCHOR_TOPLEFT")
 					GameTooltip:SetCurrencyByID(h.id)
+					if db.showDescription == false then
+						local info = C_CurrencyInfo.GetCurrencyInfo(h.id)
+						local desc = info and info.description
+						if desc and desc ~= "" then
+							for i = 2, GameTooltip:NumLines() do
+								local leftText = _G[GameTooltip:GetName() .. "TextLeft" .. i]
+								if leftText and leftText:GetText() == desc then
+									leftText:SetText("")
+									break
+								end
+							end
+						end
+					end
 					GameTooltip:Show()
 					slot.lastTip = h.id
 				end
 				return
 			end
 		end
-		if slot.lastTip ~= "default" then
+		if slot.lastTip then
 			GameTooltip:SetOwner(button, "ANCHOR_TOPLEFT")
 			GameTooltip:SetText(L["Right-Click for options"])
 			GameTooltip:Show()
-			slot.lastTip = "default"
+			slot.lastTip = nil
 		end
 	end
 	button:SetScript("OnUpdate", update)
@@ -311,7 +324,7 @@ local function checkCurrencies(stream)
 			stream.snapshot.tooltip = L["Right-Click for options"]
 		end
 	else
-		stream.snapshot.tooltip = nil
+		stream.snapshot.tooltip = L["Right-Click for options"]
 	end
 end
 


### PR DESCRIPTION
## Summary
- make currency stream obey description toggle for per-currency tooltips
- avoid stray "Right-Click for options" tooltip in currency stream

## Testing
- `luacheck EnhanceQoL/Core/Streams/Stream_Currency.lua`
- `markdownlint CHANGELOG.md` *(fails: command not found)*
- `npm install -g markdownlint-cli` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b2babee4832988fa3d6cab9a8102