### PR TITLE
Show currency ID in hover tooltip

### DIFF
--- a/EnhanceQoL/Core/Streams/Stream_Currency.lua
+++ b/EnhanceQoL/Core/Streams/Stream_Currency.lua
@@ -295,9 +295,28 @@ local provider = {
 		local tip = GameTooltip
 		tip:ClearLines()
 		tip:SetOwner(b, "ANCHOR_TOPLEFT")
-		-- tip:SetCurrencyByID(h.id)
 
-		tip:AddLine(L["Right-Click for options"])
+		local hover = stream.snapshot and stream.snapshot.hover
+		if hover and #hover > 0 then
+			local mx = GetCursorPosition()
+			local scale = b:GetEffectiveScale()
+			mx = mx / scale - b:GetLeft()
+			for _, h in ipairs(hover) do
+				if mx >= h.start and mx <= h.stop then
+					tip:SetCurrencyByID(h.id)
+					tip:AddLine(("ID %d"):format(h.id))
+					tip:AddLine(" ")
+					break
+				end
+			end
+			tip:AddLine(L["Right-Click for options"])
+		elseif stream.snapshot and stream.snapshot.tooltip then
+			for line in string.gmatch(stream.snapshot.tooltip, "[^\n]+") do
+				tip:AddLine(line)
+			end
+		else
+			tip:AddLine(L["Right-Click for options"])
+		end
 		tip:Show()
 	end,
 }


### PR DESCRIPTION
## Summary
- display the correct currency ID when hovering currencies
- append a "Right-click for options" line to the per-currency tooltip

## Testing
- `stylua EnhanceQoL/Core/Streams/Stream_Currency.lua`
- `luacheck EnhanceQoL/Core/Streams/Stream_Currency.lua`

------
https://chatgpt.com/codex/tasks/task_e_68a54f531bb48329bdf168465a4cd7fa