### PR TITLE
feat(minimap): add optional landing page menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ✨ Added
 
 - DataPanel currency stream: per-currency tooltips, optional description hiding, and red coloring when capped
+- Optional right-click menu for Landing Page minimap buttons
 
 ### 🐛 Fixed
 

--- a/EnhanceQoL/EnhanceQoL.lua
+++ b/EnhanceQoL/EnhanceQoL.lua
@@ -1218,6 +1218,16 @@ local function addMinimapFrame(container)
 				if addon.InstanceDifficulty and addon.InstanceDifficulty.SetEnabled then addon.InstanceDifficulty:SetEnabled(value) end
 			end,
 		},
+		{
+			parent = "",
+			var = "enableLandingPageMenu",
+			desc = L["enableLandingPageMenuDesc"],
+			text = L["enableLandingPageMenu"],
+			type = "CheckBox",
+			callback = function(self, _, value)
+				addon.db["enableLandingPageMenu"] = value
+			end,
+		},
 		-- {
 		-- 	parent = "",
 		-- 	var = "instanceDifficultyUseIcon",
@@ -3618,6 +3628,7 @@ local function initMisc()
 	addon.functions.InitDBValue("autoQuickLootWithShift", false)
 	addon.functions.InitDBValue("hideAzeriteToast", false)
 	addon.functions.InitDBValue("hiddenLandingPages", {})
+	addon.functions.InitDBValue("enableLandingPageMenu", false)
 	addon.functions.InitDBValue("hideMinimapButton", false)
 	addon.functions.InitDBValue("hideBagsBar", false)
 	addon.functions.InitDBValue("hideMicroMenu", false)
@@ -3808,7 +3819,9 @@ local function initMisc()
 	local function AttachRightClickMenu(button)
 		if not button or button._eqolMenuHooked then return end
 		button:HookScript("OnMouseUp", function(self, btn)
-			if btn == "RightButton" then ShowLandingMenu(self) end
+			if btn == "RightButton" and addon.db["enableLandingPageMenu"] then
+				ShowLandingMenu(self)
+			end
 		end)
 		button._eqolMenuHooked = true
 	end

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -256,6 +256,8 @@ L["enableSquareMinimap"] = "Use a square minimap instead of the normal round"
 L["enableSquareMinimapDesc"] = "This option required a reload"
 L["showInstanceDifficulty"] = "Show instance difficulty"
 L["showInstanceDifficultyDesc"] = "Replace the default icon with a short text label (NM, HC, M, M+, LFR) showing the current instance difficulty."
+L["enableLandingPageMenu"] = "Enable Landing Page context menu"
+L["enableLandingPageMenuDesc"] = "Adds a right-click menu to expansion and garrison minimap buttons"
 -- L["instanceDifficultyUseIcon"] = "Use icons for difficulty"
 
 L["Profiles"] = "Profiles"

--- a/docs/OptionsReference.md
+++ b/docs/OptionsReference.md
@@ -65,6 +65,7 @@ Each action bar can be set to appear only on mouseover:
 - **Use a square minimap** (Use a square minimap instead of the normal round).
 - **Show instance difficulty** (Display the current instance difficulty near the minimap; optionally use a custom icon).
   - Enter the texture path for the custom icon, e.g. `Interface\\ICONS\\INV_Misc_QuestionMark`.
+- **Enable Landing Page context menu** (Enable Landing Page context menu): adds a right-click menu to expansion or garrison minimap buttons.
 - **Hide Minimap Button** (Hide Minimap Button).
 - **Hide Bagsbar** (Hide Bagsbar).
 - **Hide Micro Menu** (Hide Micro Menu).


### PR DESCRIPTION
## Summary
- allow right-click landing page menu to be toggled via new Minimap option
- document new landing page menu option

## Testing
- `luacheck EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a568d462008329a1722233674a2531