### PR TITLE
Add full action button range coloring option

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -43,6 +43,7 @@ English • German • French • Spanish • Italian • Russian • Korean •
 ### Action Bars & Mouse
 
 *   Mouse-over action bars.
+*   Optional full button range coloring.
 *   Customisable mouse ring and mouse trail for better cursor visibility.
 
 ### Group & Raid Tools

--- a/EnhanceQoL/Locales/enUS.lua
+++ b/EnhanceQoL/Locales/enUS.lua
@@ -213,6 +213,10 @@ L["unitFrameScale"] = "Frame scale"
 L["UnitFrameUFExplain"] = "Applies to RAID and Party Frames"
 
 L["ActionbarHideExplain"] = 'Set the action bar to hidden and show on mouseover. This works only when your Action Bar is set to "%s" and "%s" in %s'
+L["fullButtonRangeColoring"] = "Full button range coloring"
+L["fullButtonRangeColoringDesc"] = "Tint the entire action button when out of range"
+L["rangeOverlayColor"] = "Overlay color"
+L["rangeOverlayAlpha"] = "Overlay opacity"
 
 L["enableMinimapButtonBin"] = "Enable Minimap Button Sink"
 L["enableMinimapButtonBinDesc"] = "Collect all minimap buttons in a single button"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ English • German • French • Spanish • Italian • Russian • Korean •
 ### Action Bars & Mouse
 
 *   Mouse-over action bars.
+*   Optional full button range coloring.
 *   Customisable mouse ring and mouse trail for better cursor visibility.
 
 ### Group & Raid Tools

--- a/docs/OptionsReference.md
+++ b/docs/OptionsReference.md
@@ -48,6 +48,7 @@ Each action bar can be set to appear only on mouseover:
 - mouseoverActionBar1 through mouseoverActionBar8 (main and multi bars).
 - mouseoverActionBarPet (pet bar).
 - mouseoverActionBarStanceBar (stance bar).
+- **Full button range coloring** (Tint the entire action button when a spell is out of range; includes color and opacity controls).
 
 ## Unit Frames
 - **Hide floating combat text over your character** (Hide floating combat text (damage and healing) over your character).


### PR DESCRIPTION
## Summary
- add optional out-of-range overlay for action buttons with customizable color and opacity
- document full button range coloring in README and options reference

## Testing
- `stylua EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`
- `luacheck EnhanceQoL/EnhanceQoL.lua EnhanceQoL/Locales/enUS.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a5ee47088883298d30eb420a12d3e7