### PR TITLE
Fix Combat Meter frame anchoring

### DIFF
--- a/EnhanceQoLCombatMeter/CombatMeter.lua
+++ b/EnhanceQoLCombatMeter/CombatMeter.lua
@@ -29,6 +29,26 @@ cm.MAX_HISTORY = cm.MAX_HISTORY or 30
 cm.historySelection = cm.historySelection or nil
 cm.historyUnits = cm.historyUnits or {}
 
+do
+	local groups = addon.db and addon.db["combatMeterGroups"]
+	if groups then
+		local screenH = UIParent:GetHeight()
+		for _, cfg in ipairs(groups) do
+			if cfg.point and cfg.point ~= "TOPLEFT" then
+				local w = (cfg.barWidth or 210) + (cfg.barHeight or 25) + 2
+				local temp = CreateFrame("Frame", nil, UIParent)
+				temp:SetSize(w, cfg.barHeight or 25)
+				temp:SetPoint(cfg.point, UIParent, cfg.point, cfg.x or 0, cfg.y or 0)
+				cfg.x = temp:GetLeft()
+				cfg.y = temp:GetTop() - screenH
+				cfg.point = "TOPLEFT"
+				temp:Hide()
+				temp:SetParent(nil)
+			end
+		end
+	end
+end
+
 local petOwner = cm.petOwner or {}
 cm.petOwner = petOwner
 local ownerPets = cm.ownerPets or {}

--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -308,10 +308,12 @@ local function createGroupFrame(groupConfig)
 		local parent = self:GetParent()
 		parent:StopMovingOrSizing()
 		addon.CombatMeter.functions.hideOutlinesAll()
-		local point, _, _, xOfs, yOfs = parent:GetPoint()
-		groupConfig.point = point
-		groupConfig.x = xOfs
-		groupConfig.y = yOfs
+		local left = parent:GetLeft() or 0
+		local top = parent:GetTop() or 0
+		groupConfig.x = left
+		groupConfig.y = top - UIParent:GetHeight()
+		groupConfig.point = "TOPLEFT"
+		restorePosition()
 	end)
 
 	local resetButton = CreateFrame("Button", nil, dragHandle)
@@ -416,7 +418,7 @@ local function createGroupFrame(groupConfig)
 
 	local function restorePosition()
 		frame:ClearAllPoints()
-		frame:SetPoint(groupConfig.point or "CENTER", UIParent, groupConfig.point or "CENTER", groupConfig.x or 0, groupConfig.y or 0)
+		frame:SetPoint("TOPLEFT", UIParent, "TOPLEFT", groupConfig.x or 0, groupConfig.y or 0)
 	end
 	restorePosition()
 

--- a/EnhanceQoLCombatMeter/CombatMeterUI.lua
+++ b/EnhanceQoLCombatMeter/CombatMeterUI.lua
@@ -298,6 +298,10 @@ local function createGroupFrame(groupConfig)
 
 	function frame:HideOutline() dragOutline:Hide() end
 
+	local function restorePosition()
+		frame:ClearAllPoints()
+		frame:SetPoint("TOPLEFT", UIParent, "TOPLEFT", groupConfig.x or 0, groupConfig.y or 0)
+	end
 	dragHandle:SetScript("OnDragStart", function(self)
 		local parent = self:GetParent()
 		addon.CombatMeter.functions.showOutlinesAll()
@@ -416,10 +420,6 @@ local function createGroupFrame(groupConfig)
 	dragHandle.text:SetText(metricNames[groupConfig.type] or L["Combat Meter"])
 	frame.dragHandle = dragHandle
 
-	local function restorePosition()
-		frame:ClearAllPoints()
-		frame:SetPoint("TOPLEFT", UIParent, "TOPLEFT", groupConfig.x or 0, groupConfig.y or 0)
-	end
 	restorePosition()
 
 	local function getBar(index)


### PR DESCRIPTION
## Summary
- ensure Combat Meter group frames anchor to top-left and extend downward
- convert existing group configurations to the new top-left anchor

## Testing
- `stylua EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`
- `luac -p EnhanceQoLCombatMeter/CombatMeter.lua EnhanceQoLCombatMeter/CombatMeterUI.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ab3524a54c832982ec04a7f8bcdbe9