### PR TITLE
Remove rune layout call from power bar updates

### DIFF
--- a/EnhanceQoLAura/ResourceBars.lua
+++ b/EnhanceQoLAura/ResourceBars.lua
@@ -964,7 +964,6 @@ local function updatePowerBar(type, runeSlot)
                 -- Special handling for DK Runes: six sub-bars that fill as cooldown progresses
                 if type == "RUNES" then
                         local bar = powerbar[type]
-                        layoutRunes(bar)
                         local spec = GetSpecialization() or addon.variables.unitSpec
                         local r, g, b = 0.8, 0.1, 0.1 -- Blood default
                         if spec == 2 then


### PR DESCRIPTION
## Summary
- avoid relayouting runes on every update
- keep rune layout only during bar creation, resize, or config refresh

## Testing
- `luac -p EnhanceQoLAura/ResourceBars.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b2be6fbe0c832996852c1eb1549087