### PR TITLE
Optimize health bar color updates

### DIFF
--- a/EnhanceQoLAura/ResourceBars.lua
+++ b/EnhanceQoLAura/ResourceBars.lua
@@ -675,12 +675,17 @@ local function updateHealthBar()
 				healthBar.text:Show()
 			end
 		end
+		local bracket, r, g, b
 		if percent >= 60 then
-			healthBar:SetStatusBarColor(0, 0.7, 0)
+			bracket, r, g, b = 3, 0, 0.7, 0
 		elseif percent >= 40 then
-			healthBar:SetStatusBarColor(0.7, 0.7, 0)
+			bracket, r, g, b = 2, 0.7, 0.7, 0
 		else
-			healthBar:SetStatusBarColor(0.7, 0, 0)
+			bracket, r, g, b = 1, 0.7, 0, 0
+		end
+		if healthBar._lastBracket ~= bracket then
+			healthBar:SetStatusBarColor(r, g, b)
+			healthBar._lastBracket = bracket
 		end
 
 		local combined = absorb


### PR DESCRIPTION
## Summary
- Track the last health percentage bracket on personal resource health bars
- Skip `SetStatusBarColor` calls when the color bracket hasn't changed

## Testing
- `luac -p EnhanceQoLAura/ResourceBars.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b2c29bcc7c8329a5b35906b3236492