### PR TITLE
Guard TalentReminder against missing text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - **Mouse:** Trail could stop updating when “Show ring only in combat” was enabled. Trail now runs independently.
 - **DataPanel – Friends:** Cross‑realm display sanitized (no repeated realm suffixes like “-Antonidas-Antonidas”).
 - **Dungeon Portal:** Division-by-zero when no teleports were available under certain filters.
+- **Mythic+ – Talent Reminder:** Skip loadout entries missing a `text` field to avoid errors.
 
 ---
 

--- a/EnhanceQoLMythicPlus/TalentReminder.lua
+++ b/EnhanceQoLMythicPlus/TalentReminder.lua
@@ -69,7 +69,10 @@ function addon.MythicPlus.functions.getAllLoadouts()
 		if TalentLoadoutEx then
 			if TalentLoadoutEx[addon.variables.unitClass] and TalentLoadoutEx[addon.variables.unitClass][i] then
 				for _, v in pairs(TalentLoadoutEx[addon.variables.unitClass][i]) do
-					addon.MythicPlus.variables.knownLoadout[specID][v.text .. "_" .. v.name] = "TLE: " .. v.name
+					if v.name then
+						local key = v.text and (v.text .. "_" .. v.name) or v.name
+						addon.MythicPlus.variables.knownLoadout[specID][key] = "TLE: " .. v.name
+					end
 				end
 			end
 		end


### PR DESCRIPTION
## Summary
- guard TalentReminder loadout mapping against missing text values
- document change in changelog

## Testing
- `stylua EnhanceQoLMythicPlus/TalentReminder.lua`
- `luacheck EnhanceQoLMythicPlus/TalentReminder.lua`


------
https://chatgpt.com/codex/tasks/task_e_68bb221aad6083299293c9bcf70758a3