### PR TITLE
Refactor module option trees to remove redundant general nodes

### DIFF
--- a/EnhanceQoLCombatMeter/Init.lua
+++ b/EnhanceQoLCombatMeter/Init.lua
@@ -20,9 +20,6 @@ addon.variables.statusTable.groups["combatmeter"] = true
 addon.functions.addToTree(nil, {
 	value = "combatmeter",
 	text = L["Combat Meter"],
-	children = {
-		{ value = "general", text = GENERAL },
-	},
 })
 
 local function addGeneralFrame(container)
@@ -309,10 +306,9 @@ local function addGeneralFrame(container)
 	scroll:DoLayout()
 end
 
--- TODO remove the general subtree and pack all to the rootnode so we have less menues to walk
 function addon.CombatMeter.functions.treeCallback(container, group)
 	container:ReleaseChildren()
-	if group == "combatmeter\001general" then addGeneralFrame(container) end
+	if group == "combatmeter" then addGeneralFrame(container) end
 end
 
 addon.functions.InitDBValue("combatMeterEnabled", false)

--- a/EnhanceQoLMouse/EnhanceQoLMouse.lua
+++ b/EnhanceQoLMouse/EnhanceQoLMouse.lua
@@ -393,21 +393,16 @@ local function addGeneralFrame(container)
 		groupTrail:AddChild(cbUseClass)
 	end
 end
-
--- TODO Remove the general child and pack all into the main tree "mouse"
 addon.variables.statusTable.groups["mouse"] = true
 addon.functions.addToTree(nil, {
 	value = "mouse",
 	text = MOUSE_LABEL,
-	children = {
-		{ value = "general", text = GENERAL },
-	},
 })
 
 function addon.Mouse.functions.treeCallback(container, group)
 	container:ReleaseChildren() -- Entfernt vorherige Inhalte
 	-- Prüfen, welche Gruppe ausgewählt wurde
-	if group == "mouse\001general" then addGeneralFrame(container) end
+	if group == "mouse" then addGeneralFrame(container) end
 end
 
 if addon.db["mouseRingEnabled"] then createMouseRing() end

--- a/EnhanceQoLVendor/EnhanceQoLVendor.lua
+++ b/EnhanceQoLVendor/EnhanceQoLVendor.lua
@@ -575,7 +575,6 @@ addon.functions.addToTree(nil, {
 	value = "vendor",
 	text = L["Vendor"],
 	children = {
-		{ value = "general", text = ACCESSIBILITY_GENERAL_LABEL },
 		{ value = "common", text = ITEM_QUALITY_COLORS[1].hex .. _G["ITEM_QUALITY1_DESC"] .. "|r" },
 		{ value = "uncommon", text = ITEM_QUALITY_COLORS[2].hex .. _G["ITEM_QUALITY2_DESC"] .. "|r" },
 		{ value = "rare", text = ITEM_QUALITY_COLORS[3].hex .. _G["ITEM_QUALITY3_DESC"] .. "|r" },
@@ -585,14 +584,15 @@ addon.functions.addToTree(nil, {
 	},
 }, true)
 
--- TODO pack addGeneralFrame directory into the root node, so we don't need another sub general node
 function addon.Vendor.functions.treeCallback(container, group)
 	lastEbox = nil
 	container:ReleaseChildren() -- Entfernt vorherige Inhalte
 	local _, avgItemLevelEquipped = GetAverageItemLevel()
 	addon.Vendor.variables.avgItemLevelEquipped = avgItemLevelEquipped
 	-- Prüfen, welche Gruppe ausgewählt wurde
-	if group == "vendor\001common" then
+	if group == "vendor" then
+		addGeneralFrame(container)
+	elseif group == "vendor\001common" then
 		addVendorFrame(container, 1)
 	elseif group == "vendor\001uncommon" then
 		addVendorFrame(container, 2)
@@ -604,8 +604,6 @@ function addon.Vendor.functions.treeCallback(container, group)
 		addInExcludeFrame(container, 1)
 	elseif group == "vendor\001exclude" then
 		addInExcludeFrame(container, 0)
-	elseif group == "vendor\001general" then
-		addGeneralFrame(container)
 	end
 end
 


### PR DESCRIPTION
## Summary
- flatten the Mouse module configuration tree so its options live directly under the mouse node
- flatten the Combat Meter module configuration tree to remove its redundant General node
- display the Vendor module's general options at the root while keeping rarity- and list-specific subpages intact

## Testing
- stylua EnhanceQoLMouse/EnhanceQoLMouse.lua EnhanceQoLCombatMeter/Init.lua EnhanceQoLVendor/EnhanceQoLVendor.lua

------
https://chatgpt.com/codex/tasks/task_e_68cb2ddb3828832986ed325c2dc5fd4e